### PR TITLE
Missing namespace for Kakadu 7.5

### DIFF
--- a/src/KakaduImage.h
+++ b/src/KakaduImage.h
@@ -41,6 +41,10 @@
 
 #define TILESIZE 256
 
+// Kakadu 7.5 uses namespaces
+#if KDU_MAJOR_VERSION > 7 || (KDU_MAJOR_VERSION == 7 && KDU_MINOR_VERSION >= 5)
+using namespace kdu_supp; // Also includes the `kdu_core' namespace
+#endif
 
 extern std::ofstream logfile;
 


### PR DESCRIPTION
Patch fixes a build error when using Kakadu 7.5.

Building FIF.cc without the patch:
In file included from FIF.cc:29:0:
KakaduImage.h:49:47: error: expected class-name before ‘{’ token
 class kdu_stream_message : public kdu_message {
                                               ^
KakaduImage.h:72:8: error: ‘kdu_message_formatter’ does not name a type
 static kdu_message_formatter pretty_cout(&cout_message);
        ^
KakaduImage.h:73:8: error: ‘kdu_message_formatter’ does not name a type
 static kdu_message_formatter pretty_cerr(&cerr_message);
        ^
KakaduImage.h:85:3: error: ‘kdu_codestream’ does not name a type
   kdu_codestream codestream;
   ^
KakaduImage.h:88:3: error: ‘kdu_compressed_source’ does not name a type
   kdu_compressed_source *input;
   ^
KakaduImage.h:91:3: error: ‘jpx_source’ does not name a type
   jpx_source jpx_input;
   ^
KakaduImage.h:94:3: error: ‘jp2_family_src’ does not name a type
   jp2_family_src src;
   ^
KakaduImage.h:97:3: error: ‘jpx_codestream_source’ does not name a type
   jpx_codestream_source jpx_stream;
   ^
KakaduImage.h:100:3: error: ‘kdu_stripe_decompressor’ does not name a type
   kdu_stripe_decompressor decompressor;
   ^
KakaduImage.h:103:3: error: ‘kdu_dims’ does not name a type
   kdu_dims comp_dims;
   ^
