### PR TITLE
Fixed compiling with older libmemcached on RHEL6

### DIFF
--- a/src/Memcached.h
+++ b/src/Memcached.h
@@ -27,7 +27,9 @@
 #include <string>
 #include <libmemcached/memcached.h>
 
-
+#ifdef LIBMEMCACHED_VERSION_STRING
+typedef memcached_return memcached_return_t;
+#endif
 
 /// Cache to store raw tile data
 


### PR DESCRIPTION
Older version of libmemcached on RHEL6 requires one extra typedef.