### PR TITLE
Fixed: IIP Compiles with AVX2 and SSSE3 extensions

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -227,7 +227,7 @@ if test "x${KAKADU}" = xtrue; then
 	LIBS="$LIBS $kakadu_path/apps/make/jpx.o $kakadu_path/apps/make/jp2.o $kakadu_path/apps/make/kdu_stripe_decompressor.o $kakadu_path/apps/make/ssse3_stripe_transfer.o $kakadu_path/apps/make/*.so -lpthread"
 
     AC_CHECK_FILE( $kakadu_path/apps/make/avx2_stripe_transfer.o,
-        AC_MSG_RESULT([configure: Kakadu is > v7.5.]);
+        AC_MSG_RESULT([configure: Kakadu is >= v7.5.]);
         KDU_75=true,
         AC_MSG_RESULT([configure: Kakadu is < v7.5])
     )

--- a/configure.in
+++ b/configure.in
@@ -224,7 +224,17 @@ if test "x${KAKADU}" = xtrue; then
 	AC_DEFINE(HAVE_KAKADU)
 	INCLUDES="$INCLUDES -I$kakadu_path/managed/all_includes/"
 	EXTRAS="KakaduImage.o"
-	LIBS="$LIBS $kakadu_path/apps/make/jpx.o $kakadu_path/apps/make/jp2.o $kakadu_path/apps/make/kdu_stripe_decompressor.o $kakadu_path/apps/make/*.so -lpthread"
+	LIBS="$LIBS $kakadu_path/apps/make/jpx.o $kakadu_path/apps/make/jp2.o $kakadu_path/apps/make/kdu_stripe_decompressor.o $kakadu_path/apps/make/ssse3_stripe_transfer.o $kakadu_path/apps/make/*.so -lpthread"
+
+    AC_CHECK_FILE( $kakadu_path/apps/make/avx2_stripe_transfer.o,
+        AC_MSG_RESULT([configure: Kakadu is > v7.5.]);
+        KDU_75=true,
+        AC_MSG_RESULT([configure: Kakadu is < v7.5])
+    )
+
+    if test "x${KDU_75}" = xtrue; then
+        LIBS="$LIBS $kakadu_path/apps/make/avx2_stripe_transfer.o $kakadu_path/apps/make/kdu_client_window.o"
+    fi
 fi
 
 INCLUDES="$INCLUDES -I."


### PR DESCRIPTION
Previously, compiling IIP with Kakadu 7.5+ would result in a failed build due to symbols being referenced but not found.

The problem was that since Kakadu 7.5 the necessary symbols have been separated out into their own files which were not included in the IIP build script.

The workaround was to disable SSSE3 and AVX2 in the Kakadu build scripts.

This commit fixes this problem by adding the necessary files to the build script by detecting their presence in the `apps/make` directory first. If `avx2_stripe_transfer.o` is not present, the Kakadu version is assumed to be less than 7.5; otherwise it's assumed to be >= 7.5

See: https://groups.yahoo.com/neo/groups/kakadu_jpeg2000/conversations/messages/7071

Tested on Kakadu 7.3.1, 7.4, 7.5, 7.6

Fixes #35