### PR TITLE
Fix typos in documentation, code comments and messages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -114,7 +114,7 @@
 
 19/08/2014:
 	- Added aspect ratio flag in View.h for use in CVT.cc. Also cleaned up Main.cc to remove
-	  unnecesary logging and record extra http headers.
+	  unnecessary logging and record extra http headers.
 	- Added IIIF protocol version 2.0 support via the IIIF argument.
 
 
@@ -338,7 +338,7 @@
 
 
 30/10/2012:
-	- Autoconf cleanup. Removed unneccesary autoconf files: should now use
+	- Autoconf cleanup. Removed unnecessary autoconf files: should now use
 	  autogen.sh script first before ./configure
 
 
@@ -621,7 +621,7 @@
 	- Major changes to the HTTP headers sent by iipsrv. Added
 	  HTTP Server id and Last-Modified timestamps to all server output.
 	  Checks are now made for a If-Modified-Since response and a
-	  304 Not Modified reponse returned if the timestamps match.
+	  304 Not Modified response returned if the timestamps match.
 	  This should significantly improve server performance.
 
 

--- a/README
+++ b/README
@@ -157,7 +157,7 @@ If set to -1, all the available layers will be decoded by default.
 
 FILENAME_PATTERN: Pattern that follows the name stem for a 3D or multispectral 
 sequence. eg: "_pyr_" for FZ1_pyr_000_090.tif. The default is "_pyr_". This is 
-only relevent to 3D image sequences.
+only relevant to 3D image sequences.
 
 WATERMARK: TIFF image to use as watermark file. This image should be not be 
 bigger the tile size used for TIFF tiling. If bigger, it will simply be 

--- a/autogen.sh
+++ b/autogen.sh
@@ -970,7 +970,7 @@ initialize ( ) {
     if test ! -d "$_aux_dir" ; then
 	_aux_dir=.
     else
-	$VERBOSE_ECHO "Detected auxillary directory: $_aux_dir"
+	$VERBOSE_ECHO "Detected auxiliary directory: $_aux_dir"
     fi
 
     ################################
@@ -1196,7 +1196,7 @@ if [ "x$HAVE_AUTORECONF" = "xyes" ] ; then
 	$ECHO "Warning: $AUTORECONF failed"
 
 	if test -f ltmain.sh ; then
-	    $ECHO "libtoolize being run by autoreconf is not creating ltmain.sh in the auxillary directory like it should"
+	    $ECHO "libtoolize being run by autoreconf is not creating ltmain.sh in the auxiliary directory like it should"
 	fi
 
 	$ECHO "Attempting to run the preparation steps individually"

--- a/doc/doxygen-html.conf
+++ b/doc/doxygen-html.conf
@@ -281,7 +281,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # causing a significant performance penality. 
 # If the system has enough physical memory increasing the cache will improve the 
 # performance by keeping more symbols in memory. Note that the value works on 
-# a logarithmic scale so increasing the size by one will rougly double the 
+# a logarithmic scale so increasing the size by one will roughly double the
 # memory usage. The cache size is given by this formula: 
 # 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0, 
 # corresponding to a cache size of 2^16 = 65536 symbols

--- a/src/IIPImage.h
+++ b/src/IIPImage.h
@@ -134,7 +134,7 @@ class IIPImage {
   /// Quality layers
   unsigned int quality_layers;
 
-  /// Indicate whether we have opened and initialised some paramters for this image
+  /// Indicate whether we have opened and initialised some parameters for this image
   bool isSet;
 
   /// If we have an image sequence, the current X and Y position

--- a/src/KakaduImage.cc
+++ b/src/KakaduImage.cc
@@ -305,7 +305,7 @@ RawTile KakaduImage::getTile( int seq, int ang, unsigned int res, int layers, un
 
   if( res > numResolutions ){
     ostringstream tile_no;
-    tile_no << "Kakadu :: Asked for non-existant resolution: " << res;
+    tile_no << "Kakadu :: Asked for non-existent resolution: " << res;
     throw file_error( tile_no.str() );
   }
 
@@ -326,7 +326,7 @@ RawTile KakaduImage::getTile( int seq, int ang, unsigned int res, int layers, un
 
   if( tile >= ntlx*ntly ){
     ostringstream tile_no;
-    tile_no << "Kakadu :: Asked for non-existant tile: " << tile;
+    tile_no << "Kakadu :: Asked for non-existent tile: " << tile;
     throw file_error( tile_no.str() );
   }
 

--- a/src/TPTImage.cc
+++ b/src/TPTImage.cc
@@ -196,7 +196,7 @@ RawTile TPTImage::getTile( int seq, int ang, unsigned int res, int layers, unsig
   // Check the resolution exists
   if( res > numResolutions ){
     ostringstream error;
-    error << "TPTImage :: Asked for non-existant resolution: " << res;
+    error << "TPTImage :: Asked for non-existent resolution: " << res;
     throw file_error( error.str() );
   }
 
@@ -238,7 +238,7 @@ RawTile TPTImage::getTile( int seq, int ang, unsigned int res, int layers, unsig
   // Check that a valid tile number was given  
   if( tile >= TIFFNumberOfTiles( tiff ) ) {
     ostringstream tile_no;
-    tile_no << "Asked for non-existant tile: " << tile;
+    tile_no << "Asked for non-existent tile: " << tile;
     throw file_error( tile_no.str() );
   } 
 

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -402,7 +402,7 @@ void LYR::run( Session* session, const string& argument ){
 
 void CTW::run( Session* session, const string& argument ){
 
-  /* Matrices should be formated as CTW=[a,b,c;d,e,f;g,h,i] where commas separate row values
+  /* Matrices should be formatted as CTW=[a,b,c;d,e,f;g,h,i] where commas separate row values
      and semi-colons separate columns.
      Thus, the above argument represents the 3x3 square matrix:
      [ a b c

--- a/src/View.cc
+++ b/src/View.cc
@@ -63,7 +63,7 @@ unsigned int View::getResolution(){
   res_width = width;
   res_height = height;
 
-  // Caluclate our new width and height based on the calculated resolution
+  // Calculate our new width and height based on the calculated resolution
   for( i=1; i < (max_resolutions - resolution); i++ ){
     res_width = (int) floor(res_width / 2.0);
     res_height = (int) floor(res_height / 2.0);

--- a/windows/unified installers/iipimage_IIS_x86_x64.iss
+++ b/windows/unified installers/iipimage_IIS_x86_x64.iss
@@ -249,7 +249,7 @@ begin
       +'" "'+MemcachedPathPage.Values[0]+'"',
        '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     if (ResultCode <> 0) then 
-      MsgBox('CRITICAL ERROR:' #13#13 'Error occured during installation or configuration of IIS.' #13 
+      MsgBox('CRITICAL ERROR:' #13#13 'Error occurred during installation or configuration of IIS.' #13
       'Please read Readme.txt file for information how to solve this problem.',
          mbCriticalError, MB_OK);
     // Create index.html, url shortcut to this file and configures configuration.ini for transcoder
@@ -379,7 +379,7 @@ begin
        1=First registry not found, second command failed,
        3=First command successful, second failed,
        5=Both commands failed}       
-        MsgBox('ERROR '+IntToStr(ErrorCode)+':' #13#13 'Error occured during removing virtual directory or FCGI application.'
+        MsgBox('ERROR '+IntToStr(ErrorCode)+':' #13#13 'Error occurred during removing virtual directory or FCGI application.'
           +' Please remove it manually.', mbInformation, MB_OK);
     end;
     //stop memcached so it can be uninstalled and remove memcached from Windows services


### PR DESCRIPTION
All of them were found using codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>