### PR TITLE
FastCGI socket backlog size increased to withstand higher load.

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -199,7 +199,7 @@ int main( int argc, char *argv[] )
       logfile << "No socket specified" << endl << endl;
       exit(1);
     }
-    listen_socket = FCGX_OpenSocket( socket.c_str(), 10 );
+    listen_socket = FCGX_OpenSocket( socket.c_str(), 2048 );
     if( listen_socket < 0 ){
       logfile << "Unable to open socket '" << socket << "'" << endl << endl;
       exit(1);


### PR DESCRIPTION
In my application I use Nginx to access cluster of IIPImage servers via FastCGI unix sockets. I tried to stress test my application and figured out that IIPImage servers respond with "...11: Resource temporarily unavailable..." at quite low traffic – around 40 parallel users. After few hours of investigation I found that backlog size is hardcoded as 10 which is quite low for highly loaded applications. I changed it to 2048 and recompiled. Now my application is able to withstand 1000 concurrent users. Probably it would be better to push this value as a parameter.