### PR TITLE
Small fixes to IIIF info response.

### DIFF
--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -162,8 +162,14 @@ void IIIF::run( Session* session, const string& src ){
     }
     else{
       string request_uri = session->headers["REQUEST_URI"];
+      string scheme = session->headers["HTTPS"].empty() ? "http://" : "https://";
+
+      if (request_uri.empty()) {
+        throw invalid_argument( "IIIF: REQUEST_URI was not set in FastCGI request, so the ID parameter cannot be set." );
+      }
+
       request_uri.erase( request_uri.length()-suffix.length()-1, string::npos );
-      id = "http://" + session->headers["HTTP_HOST"] + request_uri;
+      id = scheme + session->headers["HTTP_HOST"] + request_uri;
     }
 
     // Decode and escape any URL-encoded characters from our file name for JSON
@@ -194,7 +200,6 @@ void IIIF::run( Session* session, const string& src ){
 		     << "       \"supports\" : [\"regionByPct\",\"sizeByForcedWh\",\"sizeByWh\",\"sizeAboveFull\",\"rotationBy90s\",\"mirroring\",\"gray\"] }" << endl
 		     << "  ]" << endl
 		     << "}";
-
 
     // Get our Access-Control-Allow-Origin value, if any
     string cors = session->response->getCORS();

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -501,13 +501,16 @@ int main( int argc, char *argv[] )
 
       // Get several other HTTP headers
       if( (header = FCGX_GetParam("SERVER_PROTOCOL", request.envp)) ){
-	session.headers["SERVER_PROTOCOL"] = string(header);
+        session.headers["SERVER_PROTOCOL"] = string(header);
       }
       if( (header = FCGX_GetParam("HTTP_HOST", request.envp)) ){
-	session.headers["HTTP_HOST"] = string(header);
+        session.headers["HTTP_HOST"] = string(header);
       }
       if( (header = FCGX_GetParam("REQUEST_URI", request.envp)) ){
-	session.headers["REQUEST_URI"] = string(header);
+        session.headers["REQUEST_URI"] = string(header);
+      }
+      if ( (header = FCGX_GetParam("HTTPS", request.envp)) ) {
+        session.headers["HTTPS"] = string(header);
       }
 
       // Check for IF_MODIFIED_SINCE


### PR DESCRIPTION
This commit makes two small fixes to the IIIF info.json response.

1) If REQUEST_URI is not set on the FastCGI request, the server will raise an invalid_argument error, since the required `@id` parameter for the IIIF request could not be set.

2) A new session header is stored that checks the HTTPS FastCGI header. If it is present, it will ensure this scheme is reflected in the IIIF JSON info.json response. This is to prevent the situation where an info.json request is only available via https, leading the info.json to reflect an incorrect location for the image.