### PR TITLE
kakadu: Remove unneeded "extern" statement

### DIFF
--- a/src/KakaduImage.cc
+++ b/src/KakaduImage.cc
@@ -58,11 +58,6 @@ unsigned int get_nprocs_conf(){
 using namespace std;
 
 
-#ifdef DEBUG
-extern std::ofstream logfile;
-#endif
-
-
 void KakaduImage::openImage() throw (file_error)
 {
   string filename = getFileName( currentX, currentY );


### PR DESCRIPTION
The global variable logfile is already declared in the .h file.

Signed-off-by: Stefan Weil <sw@weilnetz.de>