### PR TITLE
fix IIIF invalid jpeg in gray quality and IIIF region request

### DIFF
--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -547,6 +547,7 @@ void IIIF::run( Session* session, const string& src )
   if ( ( session->view->maintain_aspect && (requested_res > 0) &&
          (requested_width == tw) && (requested_height == th) &&
          (view_left % tw == 0) && (view_top % th == 0) &&
+         (session->view->getViewWidth() % tw == 0) && (session->view->getViewHeight() % th == 0) &&
          (session->view->getViewWidth() < im_width) && (session->view->getViewHeight() < im_height) )
        ||
        ( session->view->maintain_aspect && (requested_res == 0) &&


### PR DESCRIPTION
During the resolving https://github.com/ruven/iipsrv/issues/77 (https://github.com/ruven/iipsrv/commit/624e02bafa429c0955d0f30a38195fd028d16958) there occurred two problems:

On the basis of which `maintain_aspect` some IIIF requests have begun processing internally with command `JTL` instead of `CVT`. `JTL` worked with compressed image but  `gray filter` needs a bitmap, so in this pull-request I made change for getting image without compression. This resolves https://github.com/ruven/iipsrv/issues/87.

Another problem is in case this request  
```
{scheme}://{server}{/prefix}/{identifier}/67352ccc-d1b0-11e1-89ae-279075081939/0,0,1,1/256,/0/default.jpg 
```
I want region of size of 1 pixel expanded to tile of size of 256 pixels, but I get something like that:

![tile](http://i.imgur.com/lTRDqk0.jpg)

I think this type of request must be processed by the `CVT command`, so I changed that condition determines whether this is a tile request which coincides with our tile boundaries.
