### PR TITLE
Add PNG output support for IIIF compliance

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ FEATURES
 * Fast lightweight embeddable FastCGI server module
 * High performance with inbuilt configurable cache
 * Support for gigapixel images
-* Dynamic JPEG export of whole or regions of images at any resolution
+* Dynamic JPEG and PNG export of whole or regions of images at any resolution
 * Supports IIP, Zoomify, DeepZoom and IIIF protocols
 * 1, 8, 16 and 32 bit image support including 32 bit floating point support
 * CIELAB support with automatic CIELAB->sRGB colour space conversion
@@ -57,7 +57,7 @@ See COPYING.FCGI for licensing information for these libraries.
 REQUIREMENTS
 ------------
 Requirements: libtiff, zlib and the IJG JPEG development libraries.
-Optional: libmemcached (for Memcached) and Kakadu or OpenJPEG (for JPEG2000).
+Optional: libmemcached (for Memcached) and Kakadu or OpenJPEG (for JPEG2000). libpng for PNG output support.
 
 Plus, of course, an fcgi-enabled web server. The server has been successfully
 tested on the following servers:
@@ -127,6 +127,21 @@ given, the default system verson of OpenJPEG will be used if available.
 If Kakadu support has been requested, however, OpenJPEG will be automatically 
 disabled.
 
+OPTIONAL LIBRARIES: LIBPNG
+----------------------------
+
+IIPImage is able to produce PNG images via the open source libpng
+library (http://www.libpng.org/).  If the libpng development libraries
+have been installed they should be detected during the configuration stage
+and included automatically. PNG support is currently enabled only for the
+purpose of ensuring full compliance with the IIIF protocol although it 
+would be relatively straightforward for someone to add a PTL command to 
+the IIP Protocol specification to complement the JTL command which produces 
+JPG tile output.  With the default PNG export settings of no compression
+and no compression filter, the output format is still roughly 2x slower
+than JPEG output due to the size of files.  With compression enabled at 
+the "fast" setting and no compression filter enabled, file size can be
+reduced by about 40% but encoding is approximately 3x slower.
 
 
 INSTALLATION
@@ -216,7 +231,18 @@ other image formats. This is only necessary if you have activated
 --enable-modules for ./configure and written your own image format 
 handler(s).
 
+PNG_COMPRESSION_LEVEL: The PNG compression level to use for PNG output.
+Options include Z_NO_COMPRESSION (IIP Server default), 
+Z_BEST_SPEED (compress, but not optimally), Z_BEST_COMPRESSION (smaller files, takes longer)
+Z_DEFAULT_COMPRESSION (the zlib default).
+Note: libpng uses zlib for compression; see zlib.h for more information about
+these settings.
 
+PNG_FILTER_TYPE: The PNG compression filter applied by libpng to help 
+increase the compression ratio. 
+Options include PNG_NO_FILTERS (IIP Server default), PNG_FILTER_NONE, 
+PNG_FILTER_SUB, PNG_FILTER_UP, PNG_FILTER_AVG, PNG_FILTER_PAETH, PNG_ALL_FILTERS 
+Note: see the libpng documentation for full information about these settings.
 
 
 IMAGE PATHS

--- a/configure.ac
+++ b/configure.ac
@@ -322,7 +322,7 @@ AC_CHECK_HEADERS( png.h,
 		PNG=false )
 )
 
-# Disable PNG for now
+# uncomment if PNG needs to be explicitly disabled
 # PNG=false
 
 if test "x${PNG}" = xtrue; then

--- a/configure.ac
+++ b/configure.ac
@@ -314,23 +314,23 @@ fi
 #     Check for PNG support
 #************************************************************
 
-#AC_CHECK_HEADERS( png.h,
-#	AC_SEARCH_LIBS(
-#		png_create_read_struct,
-#		png,
-#		PNG=true,
-#		PNG=false )
-#)
+AC_CHECK_HEADERS( png.h,
+	AC_SEARCH_LIBS(
+	png_create_read_struct,
+		png,
+		PNG=true,
+		PNG=false )
+)
 
 # Disable PNG for now
-#PNG=false
+# PNG=false
 
-#if test "x${PNG}" = xtrue; then
-#	AM_CONDITIONAL([ENABLE_PNG], [true])
-#	AC_DEFINE(HAVE_PNG)
-#else
-#	AM_CONDITIONAL([ENABLE_PNG], [false])
-#fi
+if test "x${PNG}" = xtrue; then
+	AM_CONDITIONAL([ENABLE_PNG], [true])
+	AC_DEFINE(HAVE_PNG)
+else
+	AM_CONDITIONAL([ENABLE_PNG], [false])
+fi
 
 
 

--- a/src/CVT.cc
+++ b/src/CVT.cc
@@ -157,7 +157,7 @@ void CVT::send( Session* session ){
 	    "Transfer-Encoding: chunked\r\n"
 #endif
 	    "\r\n",
-	    VERSION, session->response->getCacheControl().c_str(), (*session->image)->getTimestamp().c_str(), session->outputcompressor->getMimeType().c_str(), basename.c_str() );
+	    VERSION, session->response->getCacheControl().c_str(), (*session->image)->getTimestamp().c_str(), session->outputCompressor->getMimeType().c_str(), basename.c_str() );
 
   session->out->printf( (const char*) str );
 #endif
@@ -357,15 +357,15 @@ void CVT::send( Session* session ){
 
   // Initialise our output compression object - this should set the header of the image as well which is
   // immediately pushed to the client
-  session->outputcompressor->InitCompression( complete_image, resampled_height );
+  session->outputCompressor->InitCompression( complete_image, resampled_height );
 
   // Add any XMP metadata to the image there is any in the original 
   if( (*session->image)->getMetadata("xmp").size() > 0 ){
     if( session->loglevel >= 4 ) *(session->logfile) << "CVT :: Adding XMP metadata" << endl;
-    session->outputcompressor->addXMPMetadata( (*session->image)->getMetadata("xmp") );
+    session->outputCompressor->addXMPMetadata( (*session->image)->getMetadata("xmp") );
   }
 
-  len = session->outputcompressor->getHeaderSize();
+  len = session->outputCompressor->getHeaderSize();
 
 #ifdef CHUNKED
   snprintf( str, 1024, "%X\r\n", len );
@@ -373,7 +373,7 @@ void CVT::send( Session* session ){
   session->out->printf( str );
 #endif
 
-  if( session->out->putStr( (const char*) session->outputcompressor->getHeader(), len ) != len ){
+  if( session->out->putStr( (const char*) session->outputCompressor->getHeader(), len ) != len ){
     if( session->loglevel >= 1 ){
       *(session->logfile) << "CVT :: Error writing output image header" << endl;
     }
@@ -400,7 +400,7 @@ void CVT::send( Session* session ){
   unsigned char* output = new unsigned char[strip_size];
 
   // release the header pointer which is a no-op with JPG but important for PNG
-  session->outputcompressor->deleteHeader();
+  session->outputCompressor->deleteHeader();
 
 
   // there is an opportunity to go parallel with this but it would require a different approach
@@ -419,7 +419,7 @@ void CVT::send( Session* session ){
     }
 
     // Compress the strip
-    len = session->outputcompressor->CompressStrip( input, output, strip_size, strip_height );
+    len = session->outputCompressor->CompressStrip( input, output, strip_size, strip_height );
 
     if( session->loglevel >= 3 ){
       *(session->logfile) << "CVT :: Compressed data strip length is " << len << endl;
@@ -454,7 +454,7 @@ void CVT::send( Session* session ){
   }
 
   // Finish off the image compression
-  len = session->outputcompressor->Finish( output, strip_size );
+  len = session->outputCompressor->Finish( output, strip_size );
 
 #ifdef CHUNKED
   snprintf( str, 1024, "%X\r\n", len );

--- a/src/CVT.cc
+++ b/src/CVT.cc
@@ -390,6 +390,8 @@ void CVT::send( Session* session ){
     }
   }
 
+  // release the header pointer which is a no-op with JPG but important for PNG
+  session->outputCompressor->finishHeader();
 
   // Send out the data per strip of fixed height.
   // Allocate enough memory for this plus an extra 64k for instances where compressed
@@ -398,10 +400,6 @@ void CVT::send( Session* session ){
   unsigned int channels = complete_image.channels;
   unsigned int strip_size = resampled_width*channels*strip_height+65636;
   unsigned char* output = new unsigned char[strip_size];
-
-  // release the header pointer which is a no-op with JPG but important for PNG
-  session->outputCompressor->deleteHeader();
-
 
   // there is an opportunity to go parallel with this but it would require a different approach
   // in the Compressor classes - might be worth pursuing at some point - @beaudet

--- a/src/CVT.cc
+++ b/src/CVT.cc
@@ -151,13 +151,13 @@ void CVT::send( Session* session ){
 	    "X-Powered-By: IIPImage\r\n"
 	    "%s\r\n"
 	    "Last-Modified: %s\r\n"
-	    "Content-Type: image/jpeg\r\n"
+	    "Content-Type: %s\r\n"
 	    "Content-Disposition: inline;filename=\"%s.jpg\"\r\n"
 #ifdef CHUNKED
 	    "Transfer-Encoding: chunked\r\n"
 #endif
 	    "\r\n",
-	    VERSION, session->response->getCacheControl().c_str(), (*session->image)->getTimestamp().c_str(), basename.c_str() );
+	    VERSION, session->response->getCacheControl().c_str(), (*session->image)->getTimestamp().c_str(), session->outputcompressor->getMimeType().c_str(), basename.c_str() );
 
   session->out->printf( (const char*) str );
 #endif
@@ -355,28 +355,27 @@ void CVT::send( Session* session ){
     }
   }
 
+  // Initialise our output compression object - this should set the header of the image as well which is
+  // immediately pushed to the client
+  session->outputcompressor->InitCompression( complete_image, resampled_height );
 
-
-  // Initialise our JPEG compression object
-  session->jpeg->InitCompression( complete_image, resampled_height );
-
-  // Add XMP metadata if this exists
+  // Add any XMP metadata to the image there is any in the original 
   if( (*session->image)->getMetadata("xmp").size() > 0 ){
     if( session->loglevel >= 4 ) *(session->logfile) << "CVT :: Adding XMP metadata" << endl;
-    session->jpeg->addMetadata( (*session->image)->getMetadata("xmp") );
+    session->outputcompressor->addXMPMetadata( (*session->image)->getMetadata("xmp") );
   }
 
-  len = session->jpeg->getHeaderSize();
+  len = session->outputcompressor->getHeaderSize();
 
 #ifdef CHUNKED
   snprintf( str, 1024, "%X\r\n", len );
-  if( session->loglevel >= 4 ) *(session->logfile) << "CVT :: JPEG Header Chunk : " << str;
+  if( session->loglevel >= 4 ) *(session->logfile) << "CVT :: Image Header Chunk : " << str;
   session->out->printf( str );
 #endif
 
-  if( session->out->putStr( (const char*) session->jpeg->getHeader(), len ) != len ){
+  if( session->out->putStr( (const char*) session->outputcompressor->getHeader(), len ) != len ){
     if( session->loglevel >= 1 ){
-      *(session->logfile) << "CVT :: Error writing jpeg header" << endl;
+      *(session->logfile) << "CVT :: Error writing output image header" << endl;
     }
   }
 
@@ -387,19 +386,26 @@ void CVT::send( Session* session ){
   // Flush our block of data
   if( session->out->flush() == -1 ) {
     if( session->loglevel >= 1 ){
-      *(session->logfile) << "CVT :: Error flushing jpeg data" << endl;
+      *(session->logfile) << "CVT :: Error flushing output image data" << endl;
     }
   }
 
 
   // Send out the data per strip of fixed height.
   // Allocate enough memory for this plus an extra 64k for instances where compressed
-  // data is greater than uncompressed
+  // data is greater than uncompressed - for PNG, we need to supply the output pointer
   unsigned int strip_height = 128;
   unsigned int channels = complete_image.channels;
-  unsigned char* output = new unsigned char[resampled_width*channels*strip_height+65636];
-  int strips = (resampled_height/strip_height) + (resampled_height%strip_height == 0 ? 0 : 1);
+  unsigned int strip_size = resampled_width*channels*strip_height+65636;
+  unsigned char* output = new unsigned char[strip_size];
 
+  // release the header pointer which is a no-op with JPG but important for PNG
+  session->outputcompressor->deleteHeader();
+
+
+  // there is an opportunity to go parallel with this but it would require a different approach
+  // in the Compressor classes - might be worth pursuing at some point - @beaudet
+  int strips = (resampled_height/strip_height) + (resampled_height%strip_height == 0 ? 0 : 1);
   for( int n=0; n<strips; n++ ){
 
     // Get the starting index for this strip of data
@@ -409,11 +415,11 @@ void CVT::send( Session* session ){
     if( (n==strips-1) && (resampled_height%strip_height!=0) ) strip_height = resampled_height % strip_height;
 
     if( session->loglevel >= 3 ){
-      *(session->logfile) << "CVT :: About to JPEG compress strip with height " << strip_height << endl;
+      *(session->logfile) << "CVT :: About to compress strip with height " << strip_height << endl;
     }
 
     // Compress the strip
-    len = session->jpeg->CompressStrip( input, output, strip_height );
+    len = session->outputcompressor->CompressStrip( input, output, strip_size, strip_height );
 
     if( session->loglevel >= 3 ){
       *(session->logfile) << "CVT :: Compressed data strip length is " << len << endl;
@@ -429,7 +435,7 @@ void CVT::send( Session* session ){
     // Send this strip out to the client
     if( len != session->out->putStr( (const char*) output, len ) ){
       if( session->loglevel >= 1 ){
-	*(session->logfile) << "CVT :: Error writing jpeg strip data: " << len << endl;
+	*(session->logfile) << "CVT :: Error writing output image strip data: " << len << endl;
       }
     }
 
@@ -441,14 +447,14 @@ void CVT::send( Session* session ){
     // Flush our block of data
     if( session->out->flush() == -1 ) {
       if( session->loglevel >= 1 ){
-	*(session->logfile) << "CVT :: Error flushing jpeg data" << endl;
+	*(session->logfile) << "CVT :: Error flushing output image data" << endl;
       }
     }
 
   }
 
   // Finish off the image compression
-  len = session->jpeg->Finish( output );
+  len = session->outputcompressor->Finish( output, strip_size );
 
 #ifdef CHUNKED
   snprintf( str, 1024, "%X\r\n", len );
@@ -458,7 +464,7 @@ void CVT::send( Session* session ){
 
   if( session->out->putStr( (const char*) output, len ) != len ){
     if( session->loglevel >= 1 ){
-      *(session->logfile) << "CVT :: Error writing jpeg EOI markers" << endl;
+      *(session->logfile) << "CVT :: Error writing output image EOI markers" << endl;
     }
   }
 
@@ -474,7 +480,7 @@ void CVT::send( Session* session ){
 
   if( session->out->flush()  == -1 ) {
     if( session->loglevel >= 1 ){
-      *(session->logfile) << "CVT :: Error flushing jpeg tile" << endl;
+      *(session->logfile) << "CVT :: Error flushing output image tile" << endl;
     }
   }
 

--- a/src/Compressor.h
+++ b/src/Compressor.h
@@ -1,0 +1,105 @@
+/*  Generic compressor wrapper to jpeg library and png library
+
+    Copyright (C) 2000-2017 Ruven Pillay - extended by Dave Beaudet
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+
+
+#ifndef _COMPRESSOR_H
+#define _COMPRESSOR_H
+
+
+
+#include <cstdio>
+#include <string>
+#include <stdexcept>
+
+#include "RawTile.h"
+
+using namespace std;
+
+#ifdef __GNUC__
+#  include <features.h>
+#  if __GNUC_PREREQ(4,7)
+#    define OVERRIDE override
+#  else
+#    define OVERRIDE 
+#  endif
+#else
+#    define OVERRIDE 
+#endif
+
+/// Base class for IIP output images
+
+class Compressor {
+	
+    public:
+
+        virtual ~Compressor() {};
+
+        /*****************************************
+            All Virtual Methods
+        *****************************************/
+
+        /// Return the image header size
+        virtual unsigned int getHeaderSize() { return 0; }; 
+
+        /// Return a pointer to the image header itself
+        virtual unsigned char* getHeader() { return NULL; }; 
+
+        /// Clear the header data
+        virtual void deleteHeader() { }; 
+
+        /// Initialise strip based compression
+        /** If we are doing a strip based encoding, we need to first initialise
+            with InitCompression, then compress a single strip at a time using
+            CompressStrip and finally clean up using Finish
+            @param rawtile tile containing the image to be compressed
+            @param strip_height pixel height of the strip we want to compress
+        */
+        virtual void InitCompression( const RawTile& rawtile, unsigned int strip_height ) throw (string) { logfile << "compressor here" << endl;};
+
+        /// Compress a strip of image data
+        /** @param s source image data
+            @param o output buffer
+            @param olen output buffer length
+            @param tile_height pixel height of the tile we are compressing
+        */
+        virtual unsigned int CompressStrip( unsigned char* s, unsigned char* o, unsigned long olen, unsigned int tile_height ) throw (string) {};
+
+        /// Finish the strip based compression and free memory
+        /** @param output output buffer
+            @return size of output generated
+        */
+        virtual unsigned int Finish( unsigned char* output, unsigned long outputlen ) throw (string) {};
+
+        /// Compress an entire buffer of image data at once in one command
+        /** @param t tile of image data */
+        virtual int Compress( RawTile& t ) throw (string) {};
+
+        /// Add metadata to the image header
+        /** @param m metadata */
+        virtual void addXMPMetadata( const string& m ) {};
+
+        /// Add metadata to the image header
+        /** @param m metadata */
+        virtual string getMimeType() {};
+
+};
+
+
+#endif

--- a/src/Compressor.h
+++ b/src/Compressor.h
@@ -61,8 +61,8 @@ class Compressor {
         /// Return a pointer to the image header itself
         virtual unsigned char* getHeader() { return NULL; }; 
 
-        /// Clear the header data
-        virtual void deleteHeader() { }; 
+        /// Release the header data
+        virtual void finishHeader() { }; 
 
         /// Initialise strip based compression
         /** If we are doing a strip based encoding, we need to first initialise
@@ -79,29 +79,29 @@ class Compressor {
             @param olen output buffer length
             @param tile_height pixel height of the tile we are compressing
         */
-        virtual unsigned int CompressStrip( unsigned char* s, unsigned char* o, unsigned long olen, unsigned int tile_height ) throw (string) {};
+        virtual unsigned int CompressStrip( unsigned char* s, unsigned char* o, unsigned long olen, unsigned int tile_height ) throw (string) { return 0; }
 
         /// Finish the strip based compression and free memory
         /** @param output output buffer
             @return size of output generated
         */
-        virtual unsigned int Finish( unsigned char* output, unsigned long outputlen ) throw (string) {};
+        virtual unsigned int Finish( unsigned char* output, unsigned long outputlen ) throw (string) { return 0; }
 
         /// Compress an entire buffer of image data at once in one command
         /** @param t tile of image data */
-        virtual int Compress( RawTile& t ) throw (string) {};
+        virtual int Compress( RawTile& t ) throw (string) { return 0; }
 
         /// Add metadata to the image header
         /** @param m metadata */
-        virtual void addXMPMetadata( const string& m ) {};
+        virtual void addXMPMetadata( const string& m ) { }
 
         /// Add metadata to the image header
         /** @param m metadata */
-        virtual string getMimeType() {};
+        virtual string getMimeType() { return ""; }
 
         /// Set the compression quality
         /** @param factor Quality factor (0-100) */
-        virtual void setQuality( int factor ) { };
+        virtual void setQuality( int factor ) { }
 
         /// Get the current quality level
         virtual int getQuality() { return 0; }

--- a/src/Compressor.h
+++ b/src/Compressor.h
@@ -1,6 +1,6 @@
 /*  Generic compressor wrapper to jpeg library and png library
 
-    Copyright (C) 2000-2017 Ruven Pillay - extended by Dave Beaudet
+    Copyright (C) 2000-2017 Ruven Pillay, Dave Beaudet
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/Compressor.h
+++ b/src/Compressor.h
@@ -46,7 +46,7 @@ using namespace std;
 /// Base class for IIP output images
 
 class Compressor {
-	
+
     public:
 
         virtual ~Compressor() {};
@@ -98,6 +98,13 @@ class Compressor {
         /// Add metadata to the image header
         /** @param m metadata */
         virtual string getMimeType() {};
+
+        /// Set the compression quality
+        /** @param factor Quality factor (0-100) */
+        virtual void setQuality( int factor ) { };
+
+        /// Get the current quality level
+        virtual int getQuality() { return 0; }
 
 };
 

--- a/src/Environment.h
+++ b/src/Environment.h
@@ -249,6 +249,64 @@ class Environment {
     return allow_upscaling;
   }
 
+#ifdef HAVE_PNG
+
+  /****************************************
+   from zlib.h
+   #define Z_NO_COMPRESSION         0
+   #define Z_BEST_SPEED             1
+   #define Z_BEST_COMPRESSION       9
+   #define Z_DEFAULT_COMPRESSION  (-1)
+  ****************************************/
+  static int getPNGCompressionLevel(){
+    int png_compression_level = Z_NO_COMPRESSION;
+    char *envval = getenv( "PNG_COMPRESSION_LEVEL" );
+    if ( envval != NULL ) {
+      string envpara = string(envval);
+      if ( envpara.compare("Z_BEST_SPEED") )
+        png_compression_level = Z_BEST_SPEED;
+      else if ( envpara.compare("Z_BEST_COMPRESSION") )
+        png_compression_level = Z_BEST_COMPRESSION;
+      else if ( envpara.compare("Z_DEFAULT_COMPRESSION") )
+        png_compression_level = Z_DEFAULT_COMPRESSION;
+    }
+    return png_compression_level;
+  }
+
+  /****************************************
+   from png.h
+   #define PNG_NO_FILTERS     0x00
+   #define PNG_FILTER_NONE    0x08
+   #define PNG_FILTER_SUB     0x10
+   #define PNG_FILTER_UP      0x20
+   #define PNG_FILTER_AVG     0x40
+   #define PNG_FILTER_PAETH   0x80
+   #define PNG_ALL_FILTERS (PNG_FILTER_NONE | PNG_FILTER_SUB | PNG_FILTER_UP | \
+                            PNG_FILTER_AVG | PNG_FILTER_PAETH)
+  ****************************************/
+  static int getPNGFilterType(){
+    int png_ftype = PNG_NO_FILTERS;
+    char *envval = getenv( "PNG_FILTER_TYPE" );
+    if ( envval != NULL ) {
+      string envpara = string(envval);
+      if ( envpara.compare("PNG_FILTER_NONE") )
+        png_ftype = PNG_FILTER_NONE;
+      else if ( envpara.compare("PNG_FILTER_SUB") )
+        png_ftype = PNG_FILTER_SUB;
+      else if ( envpara.compare("PNG_FILTER_UP") )
+        png_ftype = PNG_FILTER_UP;
+      else if ( envpara.compare("PNG_FILTER_AVG") )
+        png_ftype = PNG_FILTER_AVG;
+      else if ( envpara.compare("PNG_FILTER_PAETH") )
+        png_ftype = PNG_FILTER_PAETH;
+      else if ( envpara.compare("PNG_ALL_FILTERS") )
+        png_ftype = PNG_ALL_FILTERS;
+    }
+    return png_ftype;
+  }
+
+#endif
+
 };
 
 

--- a/src/Environment.h
+++ b/src/Environment.h
@@ -42,6 +42,7 @@
 #define BASE_URL "";
 #define CACHE_CONTROL "max-age=86400"; // 24 hours
 #define ALLOW_UPSCALING true
+#define NO_FILTER_DEFINED -999;
 
 
 #include <string>
@@ -284,28 +285,36 @@ class Environment {
    #define PNG_ALL_FILTERS (PNG_FILTER_NONE | PNG_FILTER_SUB | PNG_FILTER_UP | \
                             PNG_FILTER_AVG | PNG_FILTER_PAETH)
   ****************************************/
-  static int getPNGFilterType(){
-    int png_ftype = PNG_NO_FILTERS;
-    char *envval = getenv( "PNG_FILTER_TYPE" );
-    if ( envval != NULL ) {
-      string envpara = string(envval);
-      if ( envpara.compare("PNG_FILTER_NONE") )
+  static int PNGFilterTypeToInt( const char *filterType ) {
+    int png_ftype = NO_FILTER_DEFINED;
+    if ( filterType != NULL ) {
+      string filter = string(filterType);
+      if ( filter.compare("PNG_FILTER_NONE") )
         png_ftype = PNG_FILTER_NONE;
-      else if ( envpara.compare("PNG_FILTER_SUB") )
+      else if ( filter.compare("PNG_FILTER_SUB") )
         png_ftype = PNG_FILTER_SUB;
-      else if ( envpara.compare("PNG_FILTER_UP") )
+      else if ( filter.compare("PNG_FILTER_UP") )
         png_ftype = PNG_FILTER_UP;
-      else if ( envpara.compare("PNG_FILTER_AVG") )
+      else if ( filter.compare("PNG_FILTER_AVG") )
         png_ftype = PNG_FILTER_AVG;
-      else if ( envpara.compare("PNG_FILTER_PAETH") )
+      else if ( filter.compare("PNG_FILTER_PAETH") )
         png_ftype = PNG_FILTER_PAETH;
-      else if ( envpara.compare("PNG_ALL_FILTERS") )
+      else if ( filter.compare("PNG_ALL_FILTERS") )
         png_ftype = PNG_ALL_FILTERS;
     }
     return png_ftype;
   }
 
-#endif
+  static int getPNGFilterType() {
+    int filterType = PNGFilterTypeToInt( getenv( "PNG_FILTER_TYPE" ) );
+    int checkType = NO_FILTER_DEFINED;
+    if ( filterType == checkType ) {
+        filterType = PNG_NO_FILTERS;
+    }
+    return 0;
+  }
+
+#endif // HAVE_PNG
 
 };
 

--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -480,7 +480,7 @@ void IIIF::run( Session* session, const string& src )
         }
 #ifdef HAVE_PNG
         if ( format == "png" )
-            session->outputcompressor=session->png;
+            session->outputCompressor=session->png;
 #endif
       }
 
@@ -492,6 +492,12 @@ void IIIF::run( Session* session, const string& src )
         session->view->colourspace = GREYSCALE;
       }
       else{
+        // IIIF image spec 2.1 says the image server SHOULD return a 400 error but if we want to support JPG and PNG
+        // lossy quality we might consider enabling a syntax that allows clients to fine tune the quality
+        // by manipulating the URL as the QLT factor of the IIP Protocol currently allows, e.g. default.90.jpg for JPEG 
+        // or default.PNG_FILTER_AVG.png for PNG, etc.  In consulting with the IIIF spec authors, this has been discussed
+        // but there were insufficient use cases to justify the spec taking it up right now.
+        // see https://github.com/IIIF/iiif.io/issues/294 for the history - @beaudet
         throw invalid_argument( "unsupported quality parameter - must be one of native, color or grey" );
       }
 

--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -470,9 +470,18 @@ void IIIF::run( Session* session, const string& src )
       if ( pos != string::npos ){
         format = quality.substr( pos + 1, string::npos );
         quality.erase( pos, string::npos );
-        if ( format != "jpg" ){
+#ifdef HAVE_PNG
+        if ( format != "jpg" && format != "png" ) {
+          throw invalid_argument( "IIIF :: Only JPEG and PNG output supported" );
+#else
+        if ( format != "jpg" ) {
           throw invalid_argument( "IIIF :: Only JPEG output supported" );
+#endif
         }
+#ifdef HAVE_PNG
+        if ( format == "png" )
+            session->outputcompressor=session->png;
+#endif
       }
 
       // Quality

--- a/src/JPEGCompressor.cc
+++ b/src/JPEGCompressor.cc
@@ -21,10 +21,6 @@
 
 #include "JPEGCompressor.h"
 
-
-using namespace std;
-
-
 #define MX 32768
 
 
@@ -160,6 +156,7 @@ void iip_term_destination( j_compress_ptr cinfo )
 
 void JPEGCompressor::InitCompression( const RawTile& rawtile, unsigned int strip_height ) throw (string)
 {
+
   // Do some initialisation
   dest = &dest_mgr;
 
@@ -254,7 +251,7 @@ void JPEGCompressor::InitCompression( const RawTile& rawtile, unsigned int strip
   We use a separate tile_height from the predefined strip_height because
   the tile height for the final row can be different
  */
-unsigned int JPEGCompressor::CompressStrip( unsigned char* input, unsigned char* output, unsigned int tile_height ) throw (string)
+unsigned int JPEGCompressor::CompressStrip( unsigned char* input, unsigned char* output, unsigned long outputlen, unsigned int tile_height ) throw (string)
 {
   JSAMPROW row[1];
   int row_stride = width * channels;
@@ -286,7 +283,7 @@ unsigned int JPEGCompressor::CompressStrip( unsigned char* input, unsigned char*
 
 
 
-unsigned int JPEGCompressor::Finish( unsigned char* output ) throw (string)
+unsigned int JPEGCompressor::Finish( unsigned char* output, unsigned long output_len ) throw (string)
 {
   dest->source = output;
 
@@ -448,6 +445,6 @@ int JPEGCompressor::Compress( RawTile& rawtile ) throw (string)
 
 
 
-void JPEGCompressor::addMetadata( const string& metadata ){
+void JPEGCompressor::addXMPMetadata( const string& metadata ){
   jpeg_write_marker( &cinfo, JPEG_APP0, (const JOCTET*) metadata.c_str(), metadata.size() );
 }

--- a/src/JPEGCompressor.h
+++ b/src/JPEGCompressor.h
@@ -39,6 +39,10 @@ extern "C"{
 #include <jpeglib.h>
 }
 
+// it has been suggested on the technical IIIF slack channel that we might want to evaluate
+// alternative JPEG library implementations, particularly mozjpeg since there has been 
+// some work has been done in that library to reduce JPEG artifacting without significant
+// performance penalties - @beaudet
 
 
 /// Expanded data destination object for buffered output used by IJG JPEG library
@@ -96,17 +100,6 @@ class JPEGCompressor : public Compressor {
     setQuality(quality);
   };
 
-  /// Set the compression quality
-  /** @param factor Quality factor (0-100) */
-  void setQuality( int factor ) {
-    if( factor < 0 ) Q = 0;
-    else if( factor > 100 ) Q = 100;
-    else Q = factor;
-  };
-
-  /// Get the current quality level
-  int getQuality() { return Q; }
-
   /*********************************************
   overriding virtual methods in Compressor class
   *********************************************/
@@ -157,6 +150,16 @@ class JPEGCompressor : public Compressor {
   /// Return mime type for this compressor
   string getMimeType() OVERRIDE { 
     return "image/jpeg"; 
+  }
+
+  void setQuality( int factor ) OVERRIDE {
+    if( factor < 0 ) Q = 0;
+    else if( factor > 100 ) Q = 100;
+    else Q = factor;
+  }
+
+  int getQuality( ) OVERRIDE {
+    return Q;
   }
 
 

--- a/src/JTL.cc
+++ b/src/JTL.cc
@@ -280,12 +280,12 @@ void JTL::send( Session* session, int resolution, int tile ){
   snprintf( str, 1024,
 	    "Server: iipsrv/%s\r\n"
 	    "X-Powered-By: IIPImage\r\n"
-	    "Content-Type: image/jpeg\r\n"
+	    "Content-Type: %s\r\n"
             "Content-Length: %d\r\n"
 	    "Last-Modified: %s\r\n"
 	    "%s\r\n"
 	    "\r\n",
-	    VERSION, len,(*session->image)->getTimestamp().c_str(), session->response->getCacheControl().c_str() );
+	    VERSION, session->jpeg->getMimeType().c_str(),len,(*session->image)->getTimestamp().c_str(), session->response->getCacheControl().c_str() );
 
   session->out->printf( str );
 #endif

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -33,7 +33,9 @@
 #include <map>
 
 #include "TPTImage.h"
+#include "Compressor.h"
 #include "JPEGCompressor.h"
+#include "PNGCompressor.h"
 #include "Tokenizer.h"
 #include "IIPResponse.h"
 #include "View.h"
@@ -276,6 +278,13 @@ int main( int argc, char *argv[] )
   // Get the allow upscaling setting
   bool allow_upscaling = Environment::getAllowUpscaling();
 
+#ifdef HAVE_PNG
+  // Get PNG Compression Level
+  int png_compression_level = Environment::getPNGCompressionLevel();
+
+  // Get PNG Filter Type
+  int png_filter_type = Environment::getPNGFilterType();
+#endif
 
   // Print out some information
   if( loglevel >= 1 ){
@@ -449,7 +458,9 @@ int main( int argc, char *argv[] )
     //  so that we can close the image on exceptions
     IIPImage *image = NULL;
     JPEGCompressor jpeg( jpeg_quality );
-
+#ifdef HAVE_PNG
+    PNGCompressor png( png_compression_level, png_filter_type ); // PNG provides lossless compression
+#endif
 
     // View object for use with the CVT command etc
     View view;
@@ -473,6 +484,12 @@ int main( int argc, char *argv[] )
       session.response = &response;
       session.view = &view;
       session.jpeg = &jpeg;
+#ifdef HAVE_PNG
+      session.png = &png;
+#endif
+      // default the compressor to jpeg - if png is requested in a IIIF request, compressor will be set there
+      // prior to generating the output - otherwise, all operations such as JTL should continue to work
+      session.outputcompressor = &jpeg;
       session.loglevel = loglevel;
       session.logfile = &logfile;
       session.imageCache = &imageCache;
@@ -577,6 +594,7 @@ int main( int argc, char *argv[] )
 	task = Task::factory( command );
 	if( task ) task->run( &session, argument );
 
+
 	if( !task ){
 	  if( loglevel >= 1 ) logfile << "Unsupported command: " << command << endl;
 	  // Unsupported command error code is 2 2
@@ -589,6 +607,7 @@ int main( int argc, char *argv[] )
 	  delete task;
 	  task = NULL;
 	}
+
 
       }
 
@@ -646,6 +665,7 @@ int main( int argc, char *argv[] )
       //////////////// End of try block ////////////////////
       //////////////////////////////////////////////////////
     }
+
 
     /* Use this for sending various HTTP status codes
      */

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -489,7 +489,7 @@ int main( int argc, char *argv[] )
 #endif
       // default the compressor to jpeg - if png is requested in a IIIF request, compressor will be set there
       // prior to generating the output - otherwise, all operations such as JTL should continue to work
-      session.outputcompressor = &jpeg;
+      session.outputCompressor = &jpeg;
       session.loglevel = loglevel;
       session.logfile = &logfile;
       session.imageCache = &imageCache;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,21 +17,22 @@ if ENABLE_OPENJPEG
 iipsrv_fcgi_LDADD += OpenJPEGImage.o
 endif
 
-#if ENABLE_PNG
-#iipsrv_fcgi_LDADD += PNGCompressor.o PTL.o
-#endif
+if ENABLE_PNG
+iipsrv_fcgi_LDADD += PNGCompressor.o # PTL.o -- for now, PNG motivation is primarily for PNG for IIIF compliance, not a new IIP Protocol command
+endif
 
 if ENABLE_MODULES
 iipsrv_fcgi_LDADD += DSOImage.o
 endif
 
-EXTRA_iipsrv_fcgi_SOURCES = DSOImage.h DSOImage.cc KakaduImage.h KakaduImage.cc Main.cc OpenJPEGImage.h OpenJPEGImage.cc
+EXTRA_iipsrv_fcgi_SOURCES = DSOImage.h DSOImage.cc KakaduImage.h KakaduImage.cc Main.cc OpenJPEGImage.h OpenJPEGImage.cc PNGCompressor.h PNGCompressor.cc
 
 iipsrv_fcgi_SOURCES = \
 			IIPImage.h \
 			IIPImage.cc \
 			TPTImage.h \
 			TPTImage.cc \
+			Compressor.h \
 			JPEGCompressor.h \
 			JPEGCompressor.cc \
 			RawTile.h \

--- a/src/PNGCompressor.cc
+++ b/src/PNGCompressor.cc
@@ -1,0 +1,412 @@
+/*  PNG class wrapper to libpng library
+
+    Copyright (C) 2012-2013 Ruven Pillay.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+
+#include "PNGCompressor.h"
+#include "Compressor.h"
+#include "Timer.h"
+#include "zlib.h"
+
+static void png_write_data(png_structp png_ptr, png_bytep payload, png_size_t length)
+{
+
+  /* some debugging code that spits the png out to a file
+  //ofstream ofs;
+  //ofs.open ("/tmp/test.png", ofstream::out | ofstream::binary | ofstream::app);
+  //ofs.write((const char*) payload, length);
+  //ofs.close();
+  // logfile << "png_write_data called with " << length << " bytes to write to mem location" << &payload << endl;
+  */
+
+  png_destination_ptr dest = (png_destination_ptr) (png_get_io_ptr(png_ptr));
+
+  if ( dest->size + length > dest->mx ) {
+    dest->mx+= (10240>length ? 10240 : length);
+    dest->data=(unsigned char*)realloc(dest->data, dest->mx); 
+  }
+  if (!memcpy(&(dest->data[dest->size]), payload, length))
+    throw std::string( "png_write_data: error writing to buffer.");
+  dest->size += length;
+
+}
+
+static void png_flush(png_structp png_ptr) { 
+    // logfile << "png flush has been called" << endl;
+}
+
+static void
+png_cexcept_error(png_structp png_ptr, png_const_charp msg)
+{
+#ifndef PNG_NO_CONSOLE_IO
+#endif
+   {
+     throw std::string(msg);
+   }
+}
+
+void PNGCompressor::InitCompression( const RawTile& rawtile, unsigned int strip_height ) throw (std::string)
+{
+
+  ofstream ofs;
+  // create an empty test file first
+  ofs.open ("/tmp/test.png", ofstream::out | ofstream::binary );
+  ofs.close();
+
+  // Set up the correct width and height for this particular tile
+  width = rawtile.width;
+  height = rawtile.height;
+  channels = rawtile.channels;
+
+  // see png_write_data where data structure, size, and mx are dealt with
+  dest.mx = 1024;                           // allocated a reasonably sized header
+  dest.data = new unsigned char[dest.mx];   // data will be resized during writing if necessary
+  dest.size = 0;                            // starts with no actual data written
+
+  // Make sure we only try to compress images with 1 or 3 channels with ir without alpha
+  if( ! ( (channels==1) || (channels==2) || (channels==3) || (channels==4))  ){
+    throw std::string( "PNGCompressor:: currently only either 1 or 3 channels are supported with or without alpha values." );
+  }
+
+  const int ciBitDepth = 8;
+
+  dest.png_ptr = png_create_write_struct( PNG_LIBPNG_VER_STRING, NULL,
+                                          (png_error_ptr)png_cexcept_error, (png_error_ptr)NULL );
+
+
+  if (!dest.png_ptr) throw std::string( "PNGCompressor:: Error allocacating png_structp." );
+
+  dest.info_ptr = png_create_info_struct(dest.png_ptr);
+  if (! dest.info_ptr) {
+    png_destroy_write_struct(&dest.png_ptr, (png_infopp) NULL);
+    throw std::string( "PNGCompressor:: Error creating png_infop." );
+  }
+
+  /*********************************************************
+   NOTES: enabling compression to Z_BEST_SPEED results in a 3x slowdown
+   e.g. png_set_compression_level( dest.png_ptr, Z_BEST_SPEED );
+   I have chosen speed vs size intially, but it probably makes sense to provide
+   a tunable configuration for this - @beaudet
+  **********************************************************/
+  png_set_compression_level( dest.png_ptr, compressionLevel );
+ 
+  /******************************************************************
+   NOTES: filters are used to prepare the PNG for optimal compression
+   I choose no filter here because I'm defaulting to no compression
+   but it probably makes sense to provide a tunable configuration for this
+  *******************************************************************/
+  png_set_filter(dest.png_ptr, NULL, filterType );
+
+  png_set_write_fn( dest.png_ptr, (png_voidp) &dest, png_write_data, png_flush );
+
+  // We're going to write a very simple 3x8 bit RGB image
+  png_set_IHDR( 
+    dest.png_ptr,  
+    dest.info_ptr, 
+    width, 
+    height, 
+    ciBitDepth,
+    ( (channels<3) ? ( (channels==2) ? PNG_COLOR_TYPE_GRAY_ALPHA : PNG_COLOR_TYPE_GRAY): ( (channels==4) ? PNG_COLOR_TYPE_RGB_ALPHA : PNG_COLOR_TYPE_RGB)), 
+    PNG_INTERLACE_NONE, 
+    PNG_COMPRESSION_TYPE_BASE, 
+    PNG_FILTER_TYPE_BASE 
+  );
+
+  // Write the header information at this point
+  png_write_info(dest.png_ptr, dest.info_ptr);
+
+}
+
+
+/* We use a separate tile_height from the predefined strip_height because
+   the tile height for the final row can be different
+   o = output buffer - not used - just here for compliance with Compressor class which isn't 
+       the best implementation so we should probably change that
+ */
+unsigned int PNGCompressor::CompressStrip( unsigned char* inputbuff, unsigned char* outputbuff, unsigned long outputbufflen, unsigned int tile_height ) throw (std::string)
+
+// the reason this isn't working is because we need to return the actual output back to the caller every time - this means
+// compress strip needs to either take the output from PNG or return it all at the end
+
+  // assumption here is that there can be multiple writes made to the PNG via our write method
+  // and that method will continue to grow the buffer as necessary in order to 
+
+{
+
+  Timer partoffunction;
+  Timer entirefunction;
+  entirefunction.start();
+
+  png_uint_32     ulRowBytes = width * channels;
+  png_byte        **ppbRowPointers = NULL;
+
+  // dest.size = 0;  //rewind output buffer - DPB - nope, we shouldn't do this
+
+  if( (ppbRowPointers = (png_bytepp) malloc(tile_height * sizeof(png_bytep))) == NULL ){
+    throw "PNGCompressor:: Out of memory";
+  }
+
+/*
+  for( int i = 0; i < tile_height; i++ ){
+    ppbRowPointers[i] = (png_byte*)(inputbuff + i *ulRowBytes);
+  }
+
+  // Write out the entire image data in one call
+  png_write_rows (dest.png_ptr, ppbRowPointers, tile_height);
+
+  free (ppbRowPointers);
+  ppbRowPointers = NULL;
+
+  logfile << "PNGCOMPRESSOR::CompressStrip Total strip compression time " << entirefunction.getTime() << " microseconds" << endl;
+
+  return dest.size;
+*/
+
+
+  // temporarily override the png write method in order to run in parallel
+  // each output call should be passed a structure that has an order - if this is possible - perhaps it is
+  // DPB
+  setOutputBuffer(outputbuff, outputbufflen);
+
+// multi-threaded doesn't work here because it jams everything into same structure out of order
+// but we might be able to assign a new output method temporarily 
+//  #if defined(__ICC) || defined(__INTEL_COMPILER)
+//  #pragma ivdep
+//  #elif defined(_OPENMP)
+//  #pragma omp parallel for
+//  #endif
+  for( int i = 0; i < tile_height; i++ ) {
+    png_write_row( dest.png_ptr, (png_byte*) &inputbuff[i*ulRowBytes] ); // &row_pointers[y], 1);
+  }
+
+  //  ppbRowPointers[i] = (png_byte*)(inputbuff + i *ulRowBytes);
+
+  // logfile << "PNGCOMPRESSOR::CompressStrip Total strip compression time " << entirefunction.getTime() << " microseconds" << endl;
+
+  return dest.size;
+}
+
+
+
+// o is output buffer and not currently used
+unsigned int PNGCompressor::Finish(unsigned char *o, unsigned long olen) throw (std::string) {
+
+  setOutputBuffer(o, olen);
+  // dest.size = 0;
+  
+  // Write any additional chunks to the PNG file 
+  png_write_end(dest.png_ptr,  dest.info_ptr);
+
+  // Clean up after the write, and free any memory allocated
+  png_destroy_write_struct(&(dest.png_ptr), (png_infopp) NULL);
+
+  return dest.size ;
+}
+
+
+int PNGCompressor::Compress( RawTile& rawtile ) throw (std::string) {
+
+  logfile << "PNGCompressor::Compress - !!!!!!!! NOT IMPLEMENTED - IIP DOESN'T !!!!!!" << endl;
+
+/*************************************************************************************************************
+ If the IIP Protocol is going to be extended with a PTL command for producing PNG tiles, this would have to be
+ implemented.  For now, I only need support via the CVT operation so I'm leaving this out - but CompressStrip
+ and the CVT command already provide pretty much everything that would have to happen and Ruven has already
+ implemented most of it below
+*************************************************************************************************************/
+ 
+/*
+ PNG OUTPUT SUPPORT
+  Timer partoffunction;
+  Timer entirefunction;
+  entirefunction.start();
+
+  png_byte    **ppbRowPointers = NULL;
+  const int   ciBitDepth = 8;
+  png_uint_32 ulRowBytes;
+
+  // Set up the correct width and height for this particular tile
+  width = rawtile.width;
+  height = rawtile.height;
+  channels = rawtile.channels;
+
+  // Make sure we only try to compress images with 1 or 3 channels
+  if( ! ( (channels==1) || (channels==2) || (channels==3) || (channels==4))  ){
+    throw std::string( "PNGCompressor:: currently only either 1 or 3 channels are supported with or without alpha values." );
+  }
+
+  dest.png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL,
+                                         (png_error_ptr)png_cexcept_error, (png_error_ptr)NULL);
+
+  if( !dest.png_ptr ) throw std::string( "PNGCompressor:: Error allocacating png_structp" );
+
+  dest.info_ptr = png_create_info_struct(dest.png_ptr);
+  if (! dest.info_ptr) {
+    png_destroy_write_struct(&(dest.png_ptr), (png_infopp) NULL);
+    throw std::string( "PNGCompressor:: Error creating png_infop" );
+  }
+
+  dest.size = 0;
+  dest.mx =  rawtile.dataLength;  //initial PNG size
+  dest.data = new unsigned char[width*height*channels];
+
+
+  png_set_write_fn( dest.png_ptr, (png_voidp) &dest, png_write_data, png_flush );
+
+  // We're going to write a very simple 3x8 bit RGB image
+  png_set_IHDR( dest.png_ptr, dest.info_ptr, width, height, ciBitDepth,
+                (channels<3) ? ((channels==2) ? PNG_COLOR_TYPE_GRAY_ALPHA : PNG_COLOR_TYPE_GRAY): ((channels==4) ? PNG_COLOR_TYPE_RGB_ALPHA : PNG_COLOR_TYPE_RGB),
+                PNG_INTERLACE_NONE, 
+                PNG_COMPRESSION_TYPE_BASE,
+                PNG_FILTER_TYPE_BASE );
+
+  // Set the zlib compression level
+  //png_set_compression_level( dest.png_ptr, Z_BEST_SPEED );
+  png_set_compression_level( dest.png_ptr, Z_NO_COMPRESSION );
+  png_set_filter(dest.png_ptr, NULL, PNG_NO_FILTERS);
+
+  // Write the file header information
+  png_write_info( dest.png_ptr, dest.info_ptr );
+
+  // row_bytes is the width x number of channels
+  ulRowBytes = width * channels;
+
+  try {
+
+    // Allocate memory for an array of row-pointers
+    if ((ppbRowPointers = (png_bytepp) malloc(height * sizeof(png_bytep))) == NULL)
+      throw "PNGCompressor:: Out of memory";
+
+    // Set the individual row-pointers to point at the correct offsets
+    for (int i = 0; i < height; i++){
+      ppbRowPointers[i] = (png_byte*)((unsigned char*)rawtile.data + i *ulRowBytes);
+    }
+
+    // Write out the entire image data in one call
+    png_write_rows(dest.png_ptr, ppbRowPointers,height);
+
+    // Write the additional chunks to the PNG file (not really needed)
+    png_write_end(dest.png_ptr,  dest.info_ptr);
+
+    // We're done
+    free (ppbRowPointers);
+    ppbRowPointers = NULL;
+
+    // Clean up after the write, and free any memory allocated
+    png_destroy_write_struct(&(dest.png_ptr), (png_infopp) NULL);
+
+  }
+  catch (char * msg){
+    png_destroy_write_struct(&(dest.png_ptr), (png_infopp) NULL);
+    if(ppbRowPointers) free (ppbRowPointers);
+    return 0;
+  }
+
+  // If dest is bigger, then realloate
+  if( dest.size > rawtile.dataLength ){
+    delete[] (unsigned char*) rawtile.data;
+    rawtile.data = new unsigned char[dest.size];
+  }
+
+  rawtile.dataLength = dest.size;
+  memcpy( rawtile.data, dest.data, rawtile.dataLength );
+  delete[] dest.data;
+  dest.data = NULL;
+  dest.size = 0;
+  dest.mx   = 0;
+
+  // Set the tile compression type
+  rawtile.compressionType = PNG;
+  rawtile.quality = 100;  // PNG is not compressed
+
+  //logfile << "PNGCOMPRESSOR::Compress Total compression time " << entirefunction.getTime() << " microseconds" << endl;
+
+  // Return the size of the data we have compressed
+  return rawtile.dataLength;
+*/
+}
+
+void PNGCompressor::addXMPMetadata( const string& xmp_metadata ){
+  /*************************************************************************************************
+     according to http://dev.exiv2.org/projects/exiv2/wiki/The_Metadata_in_PNG_files
+     embedding of XMP metadata can be done by writing an iTXt text chunk with the keyword XML:com.adobe.xmp
+     and a value containing the XML.  iTXt chunk == PNG_iTXt in png.h
+
+     png_write_chunk(png_structp png_ptr, png_bytep chunk_name, png_bytep data, png_size_t length);
+
+     e.g. png_write_chunk(png_ptr, PNG_iTXt, metadata_ptr, xmp_metadata_length_bytes);
+  ***************************************************************************************************/
+
+  /************************************************************
+  PNG SPECS for iTXt chunk type
+     Keyword:             1-79 bytes (character string)
+     Null separator:      1 byte
+     Compression flag:    1 byte
+     Compression method:  1 byte
+     Language tag:        0 or more bytes (character string)
+     Null separator:      1 byte
+     Translated keyword:  0 or more bytes
+     Null separator:      1 byte
+     Text:                0 or more bytes
+  ************************************************************/
+
+  std:string xmp_keyword = "XML:com.adobe.xmp";
+
+  int chunksize = xmp_keyword.size() + 5 + xmp_metadata.size() + 1;
+  png_byte chunk[chunksize];
+  png_byte chunktype[4] = { 'i', 'T', 'X', 't' };
+
+  int i = 0;
+  memcpy(&chunk[i], xmp_keyword.c_str(), xmp_keyword.size());       i += xmp_keyword.size();        // keyword
+  chunk[i] = '\0';                                                  i += 1;                         // null string terminated
+  chunk[i] = 0;                                                     i += 1;                         // compression flag set to 0
+  chunk[i] = PNG_ITXT_COMPRESSION_NONE;                             i += 1;                         // compression method
+  chunk[i] = '\0';                                                  i += 1;                         // language tag is empty string with null termination
+  chunk[i] = '\0';                                                  i += 1;                         // translated keyword is empty string with null termination
+  memcpy(&chunk[i], xmp_metadata.c_str(), xmp_metadata.size() );    i += xmp_metadata.size();
+
+  png_write_chunk( dest.png_ptr, chunktype, chunk, chunksize );
+
+}
+
+/********************************************************************************************************************
+void PNGCompressor.writeICCProfile(...) {
+
+From: http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html#C.iCCP
+4.2.2.4. iCCP Embedded ICC profile
+
+If the iCCP chunk is present, the image samples conform to the color space represented by the embedded ICC profile as defined by the International Color Consortium [ICC]. The color space of the ICC profile must be an RGB color space for color images (PNG color types 2, 3, and 6), or a monochrome grayscale color space for grayscale images (PNG color types 0 and 4).
+
+The iCCP chunk contains:
+
+   Profile name:       1-79 bytes (character string)
+   Null separator:     1 byte
+   Compression method: 1 byte
+   Compressed profile: n bytes
+The format is like the zTXt chunk. (see the zTXt chunk specification). The profile name can be any convenient name for referring to the profile. It is case-sensitive and subject to the same restrictions as the keyword in a text chunk: it must contain only printable Latin-1 [ISO/IEC-8859-1] characters (33-126 and 161-255) and spaces (32), but no leading, trailing, or consecutive spaces. The only value presently defined for the compression method byte is 0, meaning zlib datastream with deflate compression (see Deflate/Inflate Compression). Decompression of the remainder of the chunk yields the ICC profile.
+
+An application that writes the iCCP chunk should also write gAMA and cHRM chunks that approximate the ICC profile's transfer function, for compatibility with applications that do not use the iCCP chunk.
+
+When the iCCP chunk is present, applications that recognize it and are capable of color management [ICC] should ignore the gAMA and cHRM chunks and use the iCCP chunk instead, but applications incapable of full-fledged color management should use the gAMA and cHRM chunks if present.
+
+A file should contain at most one embedded profile, whether explicit like iCCP or implicit like sRGB.
+
+If the iCCP chunk appears, it must precede the first IDAT chunk, and it must also precede the PLTE chunk if present.
+}
+********************************************************************************************************************/
+

--- a/src/PNGCompressor.cc
+++ b/src/PNGCompressor.cc
@@ -1,6 +1,6 @@
 /*  PNG class wrapper to libpng library
 
-    Copyright (C) 2012-2013 Ruven Pillay.
+    Copyright (C) 2012-2013 Ruven Pillay with extensions by Dave Beaudet
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/PNGCompressor.cc
+++ b/src/PNGCompressor.cc
@@ -41,7 +41,7 @@ static void png_write_data(png_structp png_ptr, png_bytep payload, png_size_t le
     dest->data=(unsigned char*)realloc(dest->data, dest->mx); 
   }
   if (!memcpy(&(dest->data[dest->size]), payload, length))
-    throw std::string( "png_write_data: error writing to buffer.");
+    throw string( "png_write_data: error writing to buffer.");
   dest->size += length;
 
 }
@@ -56,11 +56,11 @@ png_cexcept_error(png_structp png_ptr, png_const_charp msg)
 #ifndef PNG_NO_CONSOLE_IO
 #endif
    {
-     throw std::string(msg);
+     throw string(msg);
    }
 }
 
-void PNGCompressor::InitCompression( const RawTile& rawtile, unsigned int strip_height ) throw (std::string)
+void PNGCompressor::InitCompression( const RawTile& rawtile, unsigned int strip_height ) throw (string)
 {
 
   ofstream ofs;
@@ -80,7 +80,7 @@ void PNGCompressor::InitCompression( const RawTile& rawtile, unsigned int strip_
 
   // Make sure we only try to compress images with 1 or 3 channels with ir without alpha
   if( ! ( (channels==1) || (channels==2) || (channels==3) || (channels==4))  ){
-    throw std::string( "PNGCompressor:: currently only either 1 or 3 channels are supported with or without alpha values." );
+    throw string( "PNGCompressor:: currently only either 1 or 3 channels are supported with or without alpha values." );
   }
 
   const int ciBitDepth = 8;
@@ -89,12 +89,12 @@ void PNGCompressor::InitCompression( const RawTile& rawtile, unsigned int strip_
                                           (png_error_ptr)png_cexcept_error, (png_error_ptr)NULL );
 
 
-  if (!dest.png_ptr) throw std::string( "PNGCompressor:: Error allocacating png_structp." );
+  if (!dest.png_ptr) throw string( "PNGCompressor:: Error allocacating png_structp." );
 
   dest.info_ptr = png_create_info_struct(dest.png_ptr);
   if (! dest.info_ptr) {
     png_destroy_write_struct(&dest.png_ptr, (png_infopp) NULL);
-    throw std::string( "PNGCompressor:: Error creating png_infop." );
+    throw string( "PNGCompressor:: Error creating png_infop." );
   }
 
   /*********************************************************
@@ -110,7 +110,7 @@ void PNGCompressor::InitCompression( const RawTile& rawtile, unsigned int strip_
    I choose no filter here because I'm defaulting to no compression
    but it probably makes sense to provide a tunable configuration for this
   *******************************************************************/
-  png_set_filter(dest.png_ptr, NULL, filterType );
+  png_set_filter(dest.png_ptr, 0, filterType );
 
   png_set_write_fn( dest.png_ptr, (png_voidp) &dest, png_write_data, png_flush );
 
@@ -138,7 +138,7 @@ void PNGCompressor::InitCompression( const RawTile& rawtile, unsigned int strip_
    o = output buffer - not used - just here for compliance with Compressor class which isn't 
        the best implementation so we should probably change that
  */
-unsigned int PNGCompressor::CompressStrip( unsigned char* inputbuff, unsigned char* outputbuff, unsigned long outputbufflen, unsigned int tile_height ) throw (std::string)
+unsigned int PNGCompressor::CompressStrip( unsigned char* inputbuff, unsigned char* outputbuff, unsigned long outputbufflen, unsigned int tile_height ) throw (string)
 {
 
   Timer partoffunction;
@@ -155,14 +155,14 @@ unsigned int PNGCompressor::CompressStrip( unsigned char* inputbuff, unsigned ch
   // ensure that the output buffer is set properly
   setOutputBuffer(outputbuff, outputbufflen);
 
-  for( int i = 0; i < tile_height; i++ ) {
+  for( unsigned int i = 0; i < tile_height; i++ ) {
     png_write_row( dest.png_ptr, (png_byte*) &inputbuff[i*ulRowBytes] ); 
   }
 
   return dest.size;
 }
 
-unsigned int PNGCompressor::Finish(unsigned char *o, unsigned long olen) throw (std::string) {
+unsigned int PNGCompressor::Finish(unsigned char *o, unsigned long olen) throw (string) {
 
   setOutputBuffer(o, olen);
   
@@ -176,7 +176,7 @@ unsigned int PNGCompressor::Finish(unsigned char *o, unsigned long olen) throw (
 }
 
 
-int PNGCompressor::Compress( RawTile& rawtile ) throw (std::string) {
+int PNGCompressor::Compress( RawTile& rawtile ) throw (string) {
 
   logfile << "PNGCompressor::Compress - !!!!!!!! NOT IMPLEMENTED - IIP DOESN'T !!!!!!" << endl;
 
@@ -204,18 +204,18 @@ int PNGCompressor::Compress( RawTile& rawtile ) throw (std::string) {
 
   // Make sure we only try to compress images with 1 or 3 channels
   if( ! ( (channels==1) || (channels==2) || (channels==3) || (channels==4))  ){
-    throw std::string( "PNGCompressor:: currently only either 1 or 3 channels are supported with or without alpha values." );
+    throw string( "PNGCompressor:: currently only either 1 or 3 channels are supported with or without alpha values." );
   }
 
   dest.png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL,
                                          (png_error_ptr)png_cexcept_error, (png_error_ptr)NULL);
 
-  if( !dest.png_ptr ) throw std::string( "PNGCompressor:: Error allocacating png_structp" );
+  if( !dest.png_ptr ) throw string( "PNGCompressor:: Error allocacating png_structp" );
 
   dest.info_ptr = png_create_info_struct(dest.png_ptr);
   if (! dest.info_ptr) {
     png_destroy_write_struct(&(dest.png_ptr), (png_infopp) NULL);
-    throw std::string( "PNGCompressor:: Error creating png_infop" );
+    throw string( "PNGCompressor:: Error creating png_infop" );
   }
 
   dest.size = 0;
@@ -296,6 +296,7 @@ int PNGCompressor::Compress( RawTile& rawtile ) throw (std::string) {
   // Return the size of the data we have compressed
   return rawtile.dataLength;
 */
+  return 0;
 }
 
 void PNGCompressor::addXMPMetadata( const string& xmp_metadata ){
@@ -322,7 +323,7 @@ void PNGCompressor::addXMPMetadata( const string& xmp_metadata ){
      Text:                0 or more bytes
   ************************************************************/
 
-  std:string xmp_keyword = "XML:com.adobe.xmp";
+  string xmp_keyword = "XML:com.adobe.xmp";
 
   int chunksize = xmp_keyword.size() + 5 + xmp_metadata.size() + 1;
   png_byte chunk[chunksize];

--- a/src/PNGCompressor.h
+++ b/src/PNGCompressor.h
@@ -1,6 +1,6 @@
 /*  IIP PNG Compressor Class
 
-    Copyright (C) 2012-2013 Ruven Pillay
+    Copyright (C) 2012-2013 Ruven Pillay with extensions by Dave Beaudet
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/PNGCompressor.h
+++ b/src/PNGCompressor.h
@@ -139,7 +139,7 @@ public:
   };
 
   /// Dump any header data
-  void deleteHeader() OVERRIDE { 
+  void finishHeader() OVERRIDE { 
     if ( dest.data != NULL )
       delete[] dest.data;
     dest.data = NULL;

--- a/src/PNGCompressor.h
+++ b/src/PNGCompressor.h
@@ -87,7 +87,7 @@ public:
     channels = 0;
 
     this->compressionLevel = compressionLevel;
-    this->filterType = filterType;
+    setQuality(filterType);
   };
 
 
@@ -146,6 +146,20 @@ public:
     dest.size = 0;
     dest.mx = 0;
   };
+
+  int getQuality( ) OVERRIDE {
+    return filterType;
+  }
+
+  void setQuality( int quality ) OVERRIDE {
+    filterType = quality;
+    if ( quality != PNG_FILTER_SUB   && 
+         quality != PNG_FILTER_UP    && 
+         quality != PNG_FILTER_AVG   && 
+         quality != PNG_FILTER_PAETH && 
+         quality != PNG_ALL_FILTERS )
+      filterType = PNG_FILTER_NONE;
+  }
 
 
 };

--- a/src/PNGCompressor.h
+++ b/src/PNGCompressor.h
@@ -1,0 +1,153 @@
+/*  IIP PNG Compressor Class
+
+    Copyright (C) 2012-2013 Ruven Pillay
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+*/
+
+
+#ifndef _PNGCOMPRESSOR_H
+#define _PNGCOMPRESSOR_H
+
+///* get internal access to png.h */
+
+#include <cstdio>
+#include <string>
+#include <iostream>
+#include <stdexcept>
+#include <png.h>
+#include "RawTile.h"
+#include "Compressor.h"
+
+using namespace std;
+
+/// Expanded data destination object for buffered output used by PNG library
+
+typedef struct {
+  unsigned char* data;              /**< data buffer */
+  size_t size;                      /**< size of data */
+  size_t mx;                        /**< allocated size of data buffer - might not be used */
+  png_structp png_ptr;              /**< png data pointer */
+  png_infop info_ptr;               /**< png info pointer */
+} png_destination_mgr;
+
+typedef png_destination_mgr * png_destination_ptr;
+
+
+/// Wrapper class to PNG library
+
+class PNGCompressor : public Compressor {
+
+private:
+
+  /// the width, height and number of channels per sample for the image
+  unsigned int width;        /**< the width of the image */
+  unsigned int height;       /**< the height of the image */
+  png_uint_32 channels;      /**< the channels per sample for the image */
+
+  png_destination_mgr dest;  /**< destination data structure */
+
+  int compressionLevel;      /**< png compression level - see zlib.h */
+  int filterType;            /**< png compression filter type - see png.h */
+
+  /// Set output buffer to the given byte pointer with preallocated size 
+  void setOutputBuffer(unsigned char* output, unsigned int allocatedSize) {
+    dest.data = output;
+    dest.mx = allocatedSize;
+    dest.size = 0;
+  }
+
+public:
+
+  /// Constructor
+  PNGCompressor( int compressionLevel, int filterType ) { 
+    dest.png_ptr = NULL;
+    dest.info_ptr = NULL;
+
+    // buffer for the data written by PNG library
+    dest.data = NULL; 
+    dest.size = 0;
+    dest.mx = 0;
+
+    width = 0;
+    height = 0;
+    channels = 0;
+
+    this->compressionLevel = compressionLevel;
+    this->filterType = filterType;
+  };
+
+
+  /// Initialise strip based compression
+  /** If we are doing a strip based encoding, we need to first initialise
+      with InitCompression, then compress a single strip at a time using
+      CompressStrip and finally clean up using Finish
+      @param rawtile tile containing the image to be compressed
+      @param strip_height pixel height of the strip we want to compress
+   */
+  void InitCompression( const RawTile& rawtile, unsigned int strip_height ) throw (std::string) OVERRIDE;
+
+
+  /// Compress a strip of image data
+  /** @param s source image data
+      @param tile_height pixel height of the tile we are compressing
+      @param o output_buffer // unused with PNG
+   */
+  unsigned int CompressStrip( unsigned char* s, unsigned char* o, unsigned long olen, unsigned int tile_height ) throw (std::string) OVERRIDE;
+
+
+  /// Finish the strip based compression and free memory
+  /** @param output output buffer
+      @return size of output generated
+   */
+  unsigned int Finish(unsigned char* output, unsigned long outputlen) throw (std::string) OVERRIDE;
+
+  /// Compress an entire buffer of image data at once in one command
+  /** @param t tile of image data */
+  int Compress( RawTile& t ) throw (std::string) OVERRIDE;
+
+  /// Add metadata to the JPEG header
+  /** @param m metadata */
+  void addXMPMetadata( const std::string& m ) OVERRIDE;
+
+  /// get mime type for this compressor
+  std::string getMimeType() OVERRIDE { 
+    return "image/png"; 
+  }
+
+  /// Return the image header size - returns the header length if called at the right time
+  unsigned int getHeaderSize() OVERRIDE { 
+    return dest.size; 
+  };
+
+  /// Return a pointer to the image header itself - returns the header if called at the right time
+  unsigned char* getHeader() OVERRIDE { 
+    return (unsigned char*) dest.data; 
+  };
+
+  /// Dump any header data
+  void deleteHeader() OVERRIDE { 
+    if ( dest.data != NULL )
+      delete[] dest.data;
+    dest.data = NULL;
+    dest.size = 0;
+    dest.mx = 0;
+  };
+
+
+};
+
+#endif

--- a/src/RawTile.h
+++ b/src/RawTile.h
@@ -27,8 +27,11 @@
 #include <string>
 #include <cstdlib>
 #include <ctime>
+#include <fstream>
 
+using namespace std;
 
+extern ofstream logfile;
 
 /// Colour spaces - GREYSCALE, sRGB and CIELAB
 enum ColourSpaces { NONE, GREYSCALE, sRGB, CIELAB };

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -81,18 +81,38 @@ void Task::checkImage(){
 void QLT::run( Session* session, const string& argument ){
 
   if( argument.length() ){
+    int factor;
 
-    int factor = atoi( argument.c_str() );
+    // we would need a PTL command in order to support this
+    if ( session->outputCompressor == session->png ) {
+      factor = Environment::PNGFilterTypeToInt(argument.c_str() );
 
-    // Check the value is realistic
-    if( factor < 0 || factor > 100 ){
-      if( session->loglevel >= 2 ){
-	*(session->logfile) << "QLT :: JPEG Quality factor of " << argument
-			    << " out of bounds. Must be 0-100" << endl;
+      // Check the value is realistic
+      int unrecognizedValue = NO_FILTER_DEFINED;
+      if( factor == unrecognizedValue ) {
+        if( session->loglevel >= 2 ){
+	  *(session->logfile) << "QLT :: PNG Image Quality factor of " << argument
+			    << " unrecognized. Consult the IIP Server documentation for a list of permitted values." << endl;
+        }
       }
     }
 
-    session->jpeg->setQuality( factor );
+    // JPEG is default
+    else {
+
+      factor = atoi( argument.c_str() );
+
+      // Check the value is realistic
+      if( factor < 0 || factor > 100 ){
+        if( session->loglevel >= 2 ){
+	  *(session->logfile) << "QLT :: Image Quality factor of " << argument
+			    << " out of bounds. Must be 0-100" << endl;
+        }
+      }
+    }
+
+    session->outputCompressor->setQuality( factor );
+
   }
 
 }

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -172,8 +172,12 @@ void CVT::run( Session* session, const string& src ){
 
   // For the moment, only deal with JPEG. If we have specified something else, give a warning
   // and send JPEG anyway
-  if( argument != "jpeg" ){
-    if( session->loglevel >= 1 ) *(session->logfile) << "CVT :: Unsupported request: '" << argument << "'. Sending JPEG." << endl;
+#ifdef HAVE_PNG
+  if( argument != "jpeg" && argument != "png" ) {
+#else
+  if( argument != "jpeg" ) {
+#endif
+    if( session->loglevel >= 1 ) *(session->logfile) << "CVT :: Unsupported output format request: '" << argument << "'. Sending JPEG." << endl;
   }
   else{
     if( session->loglevel >= 3 ) *(session->logfile) << "CVT :: JPEG output" << endl;

--- a/src/Task.h
+++ b/src/Task.h
@@ -64,6 +64,7 @@ typedef HASHMAP <std::string,IIPImage> imageCacheMapType;
 /// Structure to hold our session data
 struct Session {
   IIPImage **image;
+  Compressor* outputcompressor;
   JPEGCompressor* jpeg;
 #ifdef HAVE_PNG
   PNGCompressor* png;

--- a/src/Task.h
+++ b/src/Task.h
@@ -38,6 +38,7 @@
 #ifdef HAVE_PNG
 #include "PNGCompressor.h"
 #endif
+#include "Environment.h"
 
 
 // Define our http header cache max age (24 hours)
@@ -64,7 +65,7 @@ typedef HASHMAP <std::string,IIPImage> imageCacheMapType;
 /// Structure to hold our session data
 struct Session {
   IIPImage **image;
-  Compressor* outputcompressor;
+  Compressor* outputCompressor;
   JPEGCompressor* jpeg;
 #ifdef HAVE_PNG
   PNGCompressor* png;

--- a/src/TileManager.cc
+++ b/src/TileManager.cc
@@ -245,7 +245,7 @@ RawTile TileManager::getTile( int resolution, int tile, int xangle, int yangle, 
     // Rawtile is a pointer to the cache data, so we need to create a copy of it in case we compress it
     RawTile ttt( *rawtile );
 
-    // Do our JPEG compression iff we have an 8 bit per channel image and either 1 or 3 bands
+    // Do our JPEG compression if we have an 8 bit per channel image and either 1 or 3 bands
     if( rawtile->bpc==8 && (rawtile->channels==1 || rawtile->channels==3) ){
 
       // Crop if this is an edge tile

--- a/src/TileManager.h
+++ b/src/TileManager.h
@@ -26,9 +26,9 @@
 
 #include <fstream>
 
+#include "JPEGCompressor.h"
 #include "RawTile.h"
 #include "IIPImage.h"
-#include "JPEGCompressor.h"
 #include "Cache.h"
 #include "Timer.h"
 #include "Watermark.h"
@@ -52,7 +52,7 @@ class TileManager{
 
   /// Get a new tile from the image file
   /**
-   *  If the JPEG tile already exists in the cache, use that, otherwise check for
+   *  If the image tile already exists in the cache, use that, otherwise check for
    *  an uncompressed tile. If that does not exist either, extract a tile from the
    *  image. If this is an edge tile, crop it.
    *  @param resolution resolution number
@@ -97,7 +97,7 @@ class TileManager{
 
   /// Get a tile from the cache
   /**
-   *  If the JPEG tile already exists in the cache, use that, otherwise check for
+   *  If the image tile already exists in the cache, use that, otherwise check for
    *  an uncompressed tile. If that does not exist either, extract a tile from the
    *  image. If this is an edge tile, crop it.
    *  @param resolution resolution number


### PR DESCRIPTION
Added support for PNG output for IIIF, two new server side controls for PNG quality (filter type) and zlib compression level.  Built support for QLT command when output is PNG but that won't get called until a PTL command is added to the IIP protocol and unrevised implementation of Compress() in PNGCompressor.cc 