### PR TITLE
Added Lanczos resizing filter

### DIFF
--- a/README
+++ b/README
@@ -199,7 +199,8 @@ Default is 86400 seconds (24 hours).
 
 INTERPOLATION: Interpolation method to use for rescaling when using image export.
 Integer value. 0 for fastest nearest neighbour interpolation. 1 for bilinear
-interpolation (better quality but about 2.5x slower). Bilinear by default.
+interpolation (better quality but about 2.5x slower). 2 for approximated Lanczos 
+interpolation (best quality but about 30% slower than bilinear). Bilinear (2) is default.
 
 CORS: Cross Origin Resource Sharing setting. Disabled by default.
 Set to * to enable for all domains or specify a single domain.

--- a/src/CVT.cc
+++ b/src/CVT.cc
@@ -263,8 +263,14 @@ void CVT::send( Session* session ){
 
 
 
-  // Resize our image as requested. Use the interpolation method requested in the server configuration.
-  //  - Use bilinear interpolation by default
+  /*********************************************************************************************************
+   Resize our image as requested. Use the interpolation method requested in the server configuration.
+   - Use bilinear interpolation by default
+   - Lanczos approximation produces the best visual results of the three options
+   - it would be relatively straightforward to generalize the lanczos method for use with the other 
+     interpolation functions defined in Filters.h, e.g. Mitchell, etc. although Lanczos produces the 
+     best results of all of the FreeImage options - or more accurately - it does for paintings - @beaudet
+  *********************************************************************************************************/
   if( (view_width!=resampled_width) || (view_height!=resampled_height) ){
 
     string interpolation_type;
@@ -276,6 +282,9 @@ void CVT::send( Session* session ){
       interpolation_type = "nearest neighbour";
       filter_interpolate_nearestneighbour( complete_image, resampled_width, resampled_height );
       break;
+     case 2:
+      interpolation_type = "Lanczos approximation";
+      filter_interpolate_lanczos( complete_image, resampled_width, resampled_height );
      default:
       interpolation_type = "bilinear";
       filter_interpolate_bilinear( complete_image, resampled_width, resampled_height );

--- a/src/Filters.cc
+++ b/src/Filters.cc
@@ -1,0 +1,153 @@
+// ==========================================================
+// Upsampling / downsampling classes
+//
+// Design and implementation by
+// - Hervé Drolon (drolon@infonie.fr)
+// - Detlev Vendt (detlev.vendt@brillit.de)
+// - Carsten Klein (cklein05@users.sourceforge.net)
+//
+// This file is part of FreeImage 3
+//
+// COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES
+// THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE
+// OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED
+// CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT
+// THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY
+// SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL
+// PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER
+// THIS DISCLAIMER.
+//
+// Use at your own risk!
+// ==========================================================
+
+// Note: a good portion of this file was removed for use by the IIP Server project
+// and other portions were modified and / or fixed - @beaudet
+
+#include "Filters.h"
+
+CWeightsTable::CWeightsTable(CGenericFilter *pFilter, unsigned uDstSize, unsigned uSrcSize) {
+    double dWidth; // should probably be called dRadius instead of width
+    double dFScale;
+    const double dFilterWidth = pFilter->GetWidth();
+
+    // scale factor
+    const double dScale = double(uDstSize) / double(uSrcSize);
+
+    if(dScale < 1.0) {
+        // minification
+        dWidth = dFilterWidth / dScale; 
+        dFScale = dScale; 
+    } else {
+        // magnification
+	dWidth = dFilterWidth; 
+	dFScale = 1.0; 
+    }
+
+    // allocate a new line contributions structure
+    // window size is the number of sampled pixels -- only used for memory allocation
+    m_WindowSize = 2 * (int)ceil(dWidth) + 1; 
+
+    // length of dst line (no. of rows / cols) 
+    m_LineLength = uDstSize; 
+
+    // allocate list of contributions 
+    m_WeightTable = (Contribution*)malloc(m_LineLength * sizeof(Contribution));
+    for(unsigned u = 0; u < m_LineLength; u++) {
+        // allocate contributions for every pixel
+        m_WeightTable[u].Weights = (double*)malloc(m_WindowSize * sizeof(double));
+        m_WeightTable[u].intWeights = (int*)malloc(m_WindowSize * sizeof(int));
+    }
+
+    /*****************************************************************************************
+     offset for discrete to continuous coordinate conversion - this isn't correct - it needs 
+     to slide with the position X - it's not FIXED!!!!
+     // const double dOffset = (0.5 / dScale);
+
+     iterate the line in the destination - e.g., for horizontal scaling it would be a scan 
+     line in the destination and for each pixel location in the destination, compute the left 
+     and right indexes to use in the sample as well as the weights to assign to each of them 
+     based on the weighting function of the filter, e.g. Filter() which accepts a distance 
+     between the center of the source pixel and the center in the sample source that is 
+     equivalent to the exact center in the destination
+    ******************************************************************************************/
+    for (unsigned u = 0; u < m_LineLength; u++) {
+        /*****************************************************************************************
+         scan through line of contributions
+         dCenter is the exact center in the source sample corresponding to the exact center in the 
+         destination (which is why it's a double) we need to add a half pixel to the destination 
+         location before dividing by the scale in order to get the true center in the sample
+        *****************************************************************************************/
+        const double dCenter = ( (double) u ) + 0.5;
+	const double sCenter = dCenter / dScale; 
+
+        // ensure the left index into the source sample is never < 0 even if the filter extends farther to the right
+        const int iLeft  = MAX( 0, (int) ( sCenter - dWidth ));              
+            
+        /*****************************************************************************************
+         ensure the right index into the source sample never exceeds the source width -- for 
+         extremely small samples, iLeft-iRight could be < m_WindowSize 
+         DPB the index of the right side should never exceed the max index of the source image which is width - 1
+        *****************************************************************************************/
+	const int iRight = MIN( (int) (iLeft + dWidth*2), int(uSrcSize)-1);  
+
+	m_WeightTable[u].Left  = iLeft;     // the start index of the sample for this section of the source image
+	m_WeightTable[u].Right = iRight;    // the end index of the sample for this section of the source image
+
+	double dTotalWeight = 0;            // sum of weights (initialized to zero but will sum exactly to 1 to 
+                                            // accurately distribute the sample pixels to the destination pixel)
+	for (int iSrc = iLeft; iSrc <= iRight; iSrc++) { // @beaudet corrected to <= iRight
+           /*****************************************************************************************
+             calculate weights; DPB - dFScale adjusts the distance passed to Filter() from source pixels to destination pixels 
+             but why is it multiplied twice instead of once?  should only be once I think - we can experiment to find out - DPB
+             a half pixel is added here in order to calculate the center of the reference source pixel exactly
+	     //const double weight = dFScale * pFilter->Filter(dFScale * ( (double) iSrc + 0.5 - sCenter));  
+            *****************************************************************************************/
+	    const double weight = pFilter->Filter(dFScale * ( (double) iSrc + 0.5 - sCenter));  
+	    // assert((iSrc-iLeft) < m_WindowSize);
+
+            // assign the weight to the proper array index
+	    m_WeightTable[u].Weights[iSrc-iLeft] = weight;
+	    m_WeightTable[u].intWeights[iSrc-iLeft] = weight * INTSCALER;
+	    dTotalWeight += weight;
+	}
+
+        // normalize the weights = they MUST total exactly one in order to property distribute the pixel values
+	if ( (dTotalWeight > 0) && (dTotalWeight != 1) ) {
+	    // normalize weight of neighbouring points
+	    for (int iSrc = iLeft; iSrc <= iRight; iSrc++) {
+	        // normalize point
+	        m_WeightTable[u].Weights[iSrc-iLeft] /= dTotalWeight; 
+	        m_WeightTable[u].intWeights[iSrc-iLeft] =  m_WeightTable[u].Weights[iSrc-iLeft] * INTSCALER;
+            }
+	}
+
+        /*****************************************************************************************
+         removed since the IIP resize function discards zero weights instead
+        *****************************************************************************************/
+        /*
+	int iTrailing = iRight - iLeft - 1;
+	while ( m_WeightTable[u].Weights[iTrailing] == 0) {
+	    m_WeightTable[u].Right--;
+	    iTrailing--;
+	    if ( m_WeightTable[u].Right == m_WeightTable[u].Left ) {
+	        break;
+	    }
+        }
+        */
+    } // next dst pixel
+}
+
+CWeightsTable::~CWeightsTable() {
+    for(unsigned u = 0; u < m_LineLength; u++) {
+        // free contributions for every pixel
+        free(m_WeightTable[u].Weights);
+        free(m_WeightTable[u].intWeights);
+    }
+    // free list of pixels contributions
+    free(m_WeightTable);
+}
+
+/********************************************************************************
+ remainder of file removed since IIP uses an optimized resizing engine - @beaudet
+*********************************************************************************/

--- a/src/Filters.h
+++ b/src/Filters.h
@@ -1,0 +1,441 @@
+// ==========================================================
+// Upsampling / downsampling filters
+//
+// Design and implementation by
+// - Hervé Drolon (drolon@infonie.fr)
+//
+// This file is part of FreeImage 3
+//
+// COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES
+// THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE
+// OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED
+// CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT
+// THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY
+// SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL
+// PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER
+// THIS DISCLAIMER.
+//
+// Use at your own risk!
+// ==========================================================
+
+#ifndef _FILTERS_H_
+#define _FILTERS_H_
+
+#include <cmath>
+#include <fstream>
+#include <stdlib.h>
+
+using namespace std;
+
+extern ofstream logfile;
+
+/// Max function
+template <class T> T MAX(const T &a, const T &b) {
+        return (a > b) ? a: b;
+}
+
+/// Min function
+template <class T> T MIN(const T &a, const T &b) {
+        return (a < b) ? a: b;
+}
+
+/// Clamp function
+template <class T> T CLAMP(const T &value, const T &min_value, const T &max_value) {
+        return ((value < min_value) ? min_value : (value > max_value) ? max_value : value);
+}
+
+#define INTSCALER 1000000
+
+/**
+ CGenericFilter is a generic abstract filter class used to access to the filter library.<br>
+ Filters used in this library have been mainly taken from the following references : <br>
+<b>Main reference</b> : <br>
+Paul Heckbert, C code to zoom raster images up or down, with nice filtering. 
+UC Berkeley, August 1989. [online] http://www-2.cs.cmu.edu/afs/cs.cmu.edu/Web/People/ph/heckbert.html
+
+<b>Heckbert references</b> : <br>
+<ul>
+<li>Oppenheim A.V., Schafer R.W., Digital Signal Processing, Prentice-Hall, 1975
+<li>Hamming R.W., Digital Filters, Prentice-Hall, Englewood Cliffs, NJ, 1983
+<li>Pratt W.K., Digital Image Processing, John Wiley and Sons, 1978
+<li>Hou H.S., Andrews H.C., "Cubic Splines for Image Interpolation and Digital Filtering", 
+IEEE Trans. Acoustics, Speech, and Signal Proc., vol. ASSP-26, no. 6, pp. 508-517, Dec. 1978.
+</ul>
+
+*/
+class CGenericFilter
+{
+protected:
+
+    #define FILTER_PI  double (3.1415926535897932384626433832795)
+    #define FILTER_2PI double (2.0 * 3.1415926535897932384626433832795)
+    #define FILTER_4PI double (4.0 * 3.1415926535897932384626433832795)
+
+    /// Filter support
+	double  m_dWidth;
+
+public:
+    
+    /// Constructor
+	CGenericFilter (double dWidth) : m_dWidth (dWidth) {}
+	/// Destructor
+    virtual ~CGenericFilter() {}
+
+    /// Returns the filter support
+	double GetWidth()                   { return m_dWidth; }
+	/// Change the filter suport
+    void   SetWidth (double dWidth)     { m_dWidth = dWidth; }
+
+    /// Returns F(dVal) where F is the filter's impulse response
+	virtual double Filter (double dVal) = 0;
+};
+
+// -----------------------------------------------------------------------------------
+// Filters library
+// All filters are centered on 0
+// -----------------------------------------------------------------------------------
+
+/**
+ Box filter<br>
+ Box, pulse, Fourier window, 1st order (constant) b-spline.<br><br>
+
+ <b>Reference</b> : <br>
+ Glassner A.S., Principles of digital image synthesis. Morgan Kaufmann Publishers, Inc, San Francisco, Vol. 2, 1995
+*/
+class CBoxFilter : public CGenericFilter
+{
+public:
+    /**
+	Constructor<br>
+	Default fixed width = 0.5
+	*/
+    CBoxFilter() : CGenericFilter(0.5) {}
+    virtual ~CBoxFilter() {}
+
+    double Filter (double dVal) { return (fabs(dVal) <= m_dWidth ? 1.0 : 0.0); }
+};
+
+/** Bilinear filter
+*/
+class CBilinearFilter : public CGenericFilter
+{
+public:
+
+    CBilinearFilter () : CGenericFilter(1) {}
+    virtual ~CBilinearFilter() {}
+
+    double Filter (double dVal) {
+		dVal = fabs(dVal); 
+		return (dVal < m_dWidth ? m_dWidth - dVal : 0.0); 
+	}
+};
+
+
+/**
+ Mitchell & Netravali's two-param cubic filter<br>
+
+ The parameters b and c can be used to adjust the properties of the cubic. 
+ They are sometimes referred to as "blurring" and "ringing" respectively. 
+ The default is b = 1/3 and c = 1/3, which were the values recommended by 
+ Mitchell and Netravali as yielding the most visually pleasing results in subjective tests of human beings. 
+ Larger values of b and c can produce interesting op-art effects--for example, try b = 0 and c = -5. <br><br>
+
+ <b>Reference</b> : <br>
+ Don P. Mitchell and Arun N. Netravali, Reconstruction filters in computer graphics. 
+ In John Dill, editor, Computer Graphics (SIGGRAPH '88 Proceedings), Vol. 22, No. 4, August 1988, pp. 221-228.
+*/
+class CBicubicFilter : public CGenericFilter
+{
+protected:
+	// data for parameterized Mitchell filter
+    double p0, p2, p3;
+    double q0, q1, q2, q3;
+
+public:
+    /**
+	Constructor<br>
+	Default fixed width = 2
+	@param b Filter parameter (default value is 1/3)
+	@param c Filter parameter (default value is 1/3)
+	*/
+    CBicubicFilter (double b = (1/(double)3), double c = (1/(double)3)) : CGenericFilter(2) {
+		p0 = (6 - 2*b) / 6;
+		p2 = (-18 + 12*b + 6*c) / 6;
+		p3 = (12 - 9*b - 6*c) / 6;
+		q0 = (8*b + 24*c) / 6;
+		q1 = (-12*b - 48*c) / 6;
+		q2 = (6*b + 30*c) / 6;
+		q3 = (-b - 6*c) / 6;
+	}
+    virtual ~CBicubicFilter() {}
+
+    double Filter(double dVal) { 
+		dVal = fabs(dVal);
+		if(dVal < 1)
+			return (p0 + dVal*dVal*(p2 + dVal*p3));
+		if(dVal < 2)
+			return (q0 + dVal*(q1 + dVal*(q2 + dVal*q3)));
+		return 0;
+	}
+};
+
+/**
+ Catmull-Rom spline, Overhauser spline<br>
+
+ When using CBicubicFilter filters, you have to set parameters b and c such that <br>
+ b + 2 * c = 1<br>
+ in order to use the numerically most accurate filter.<br>
+ This gives for b = 0 the maximum value for c = 0.5, which is the Catmull-Rom 
+ spline and a good suggestion for sharpness.<br><br>
+
+
+ <b>References</b> : <br>
+ <ul>
+ <li>Mitchell Don P., Netravali Arun N., Reconstruction filters in computer graphics. 
+ In John Dill, editor, Computer Graphics (SIGGRAPH '88 Proceedings), Vol. 22, No. 4, August 1988, pp. 221-228.
+ <li>Keys R.G., Cubic Convolution Interpolation for Digital Image Processing. 
+ IEEE Trans. Acoustics, Speech, and Signal Processing, vol. 29, no. 6, pp. 1153-1160, Dec. 1981.
+ </ul>
+
+*/
+class CCatmullRomFilter : public CGenericFilter
+{
+public:
+
+    /**
+	Constructor<br>
+	Default fixed width = 2
+	*/
+	CCatmullRomFilter() : CGenericFilter(2) {}
+    virtual ~CCatmullRomFilter() {}
+
+    double Filter(double dVal) { 
+		if(dVal < -2) return 0;
+		if(dVal < -1) return (0.5*(4 + dVal*(8 + dVal*(5 + dVal))));
+		if(dVal < 0)  return (0.5*(2 + dVal*dVal*(-5 - 3*dVal)));
+		if(dVal < 1)  return (0.5*(2 + dVal*dVal*(-5 + 3*dVal)));
+		if(dVal < 2)  return (0.5*(4 + dVal*(-8 + dVal*(5 - dVal))));
+		return 0;
+	}
+};
+
+/**
+ Lanczos-windowed sinc filter<br>
+ 
+ Lanczos3 filter is an alternative to CBicubicFilter with high values of c about 0.6 ... 0.75 
+ which produces quite strong sharpening. It usually offers better quality (fewer artifacts) and a sharp image.<br><br>
+
+*/
+class CLanczos3Filter : public CGenericFilter
+{
+public:
+    /**
+	Constructor<br>
+	Default fixed width = 3
+	*/
+	CLanczos3Filter() : CGenericFilter(3) {}
+    virtual ~CLanczos3Filter() {}
+
+    double Filter(double dVal) { 
+		dVal = fabs(dVal); 
+		if(dVal < m_dWidth)	{
+			return (sinc(dVal) * sinc(dVal / m_dWidth));
+		}
+		return 0;
+	}
+
+private:
+	double sinc(double value) {
+		if(value != 0) {
+			value *= FILTER_PI;
+			return (sin(value) / value);
+		} 
+		return 1;
+	}
+};
+
+/**
+ 4th order (cubic) b-spline<br>
+
+*/
+class CBSplineFilter : public CGenericFilter
+{
+public:
+
+    /**
+	Constructor<br>
+	Default fixed width = 2
+	*/
+	CBSplineFilter() : CGenericFilter(2) {}
+    virtual ~CBSplineFilter() {}
+
+    double Filter(double dVal) { 
+
+		dVal = fabs(dVal);
+		if(dVal < 1) return (4 + dVal*dVal*(-6 + 3*dVal)) / 6;
+		if(dVal < 2) {
+			double t = 2 - dVal;
+			return (t*t*t / 6);
+		}
+		return 0;
+	}
+};
+
+// -----------------------------------------------------------------------------------
+// Window function library
+// -----------------------------------------------------------------------------------
+
+/** 
+ Blackman window
+*/
+class CBlackmanFilter : public CGenericFilter
+{
+public:
+    /**
+	Constructor<br>
+	Default width = 0.5
+	*/
+    CBlackmanFilter (double dWidth = double(0.5)) : CGenericFilter(dWidth) {}
+    virtual ~CBlackmanFilter() {}
+
+    double Filter (double dVal) {
+		if(fabs (dVal) > m_dWidth) {
+			return 0; 
+        }
+        double dN = 2 * m_dWidth + 1; 
+		dVal /= (dN - 1);
+        return 0.42 + 0.5*cos(FILTER_2PI*dVal) + 0.08*cos(FILTER_4PI*dVal); 
+    }
+};
+
+
+/**
+  Filter weights table.<br>
+  This class stores contribution information for an entire line (row or column).
+*/
+class CWeightsTable
+{
+/**
+  Sampled filter weight table.<br>
+  Contribution information for a single pixel
+*/
+typedef struct {
+	/// Normalized weights of neighboring pixels
+	double *Weights;
+	int *intWeights;
+	/// Bounds of source pixels window
+	unsigned Left, Right;
+} Contribution;
+
+private:
+	/// Row (or column) of contribution weights 
+	Contribution *m_WeightTable;
+	/// Filter window size (of affecting source pixels) 
+	unsigned m_WindowSize;
+	/// Length of line (no. of rows / cols) 
+	unsigned m_LineLength;
+
+public:
+	/** 
+	Constructor<br>
+	Allocate and compute the weights table
+	@param pFilter Filter used for upsampling or downsampling
+	@param uDstSize Length (in pixels) of the destination line buffer
+	@param uSrcSize Length (in pixels) of the source line buffer
+	*/
+	CWeightsTable(CGenericFilter *pFilter, unsigned uDstSize, unsigned uSrcSize);
+
+	/**
+	Destructor<br>
+	Destroy the weights table
+	*/
+	~CWeightsTable();
+
+	/** Retrieve a filter weight, given source and destination positions
+	@param dst_pos Pixel position in destination line buffer
+	@param src_pos Pixel position in source line buffer
+	@return Returns the filter weight
+	*/
+	double getWeight(unsigned dst_pos, unsigned src_pos) {
+		return m_WeightTable[dst_pos].Weights[src_pos];
+	}
+
+	/** Retrieve a filter weight, given source and destination positions
+	@param dst_pos Pixel position in destination line buffer
+	@param src_pos Pixel position in source line buffer
+	@return Returns the filter weight
+	*/
+	int getIntWeight(unsigned dst_pos, unsigned src_pos) {
+		return m_WeightTable[dst_pos].intWeights[src_pos];
+	}
+
+	/** Retrieve left boundary of source line buffer
+	@param dst_pos Pixel position in destination line buffer
+	@return Returns the left boundary of source line buffer
+	*/
+	unsigned getLeftBoundary(unsigned dst_pos) {
+		return m_WeightTable[dst_pos].Left;
+	}
+
+	/** Retrieve right boundary of source line buffer
+	@param dst_pos Pixel position in destination line buffer
+	@return Returns the right boundary of source line buffer
+	*/
+	unsigned getRightBoundary(unsigned dst_pos) {
+		return m_WeightTable[dst_pos].Right;
+	}
+
+	/** Retrieve window size
+	@return Returns the size of the sample in source pixels
+	*/
+	unsigned getWindowSize() {
+		return m_WindowSize;
+	}
+};
+
+// IIP Weight - used as cache in IIP Lanczos resize function
+class Weight {
+
+    public:
+
+    int minIdx;
+    int maxIdx;
+    int numWeights;
+    int *weights;
+
+    Weight() {
+        minIdx = -1;
+        maxIdx = -1;
+        numWeights = 0;
+        weights = NULL;
+    }
+
+    ~Weight() {
+        if ( weights != NULL )
+            delete[] weights;
+    }
+
+    void newWeights(int maxWeights) {
+        weights = new int[maxWeights];
+        numWeights = 0;
+        for (int j=0; j<maxWeights; j++) {
+            weights[j] = 0;
+        }
+    }
+
+    void addWeight(int pos, int weight) {
+        weights[numWeights++] = weight;
+        if (minIdx < 0 || minIdx > pos)
+            minIdx = pos;
+        if (maxIdx < 0 || maxIdx < pos)
+            maxIdx = pos;
+    }
+
+    int getNumWeights() {
+        return numWeights;
+    }
+};
+
+
+#endif  // _FILTERS_H_

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,6 +34,8 @@ iipsrv_fcgi_SOURCES = \
 			TPTImage.cc \
 			JPEGCompressor.h \
 			JPEGCompressor.cc \
+                        Filters.h \
+                        Filters.cc \
 			RawTile.h \
 			Timer.h \
 			Cache.h \

--- a/src/RawTile.h
+++ b/src/RawTile.h
@@ -28,7 +28,10 @@
 #include <cstdlib>
 #include <ctime>
 
-
+// for convenience 
+#define byte unsigned char
+#define uint unsigned int
+#define ulong unsigned long
 
 /// Colour spaces - GREYSCALE, sRGB and CIELAB
 enum ColourSpaces { NONE, GREYSCALE, sRGB, CIELAB };

--- a/src/Transforms.h
+++ b/src/Transforms.h
@@ -89,6 +89,12 @@ void filter_interpolate_nearestneighbour( RawTile& in, unsigned int w, unsigned 
 */
 void filter_interpolate_bilinear( RawTile& in, unsigned int w, unsigned int h );
 
+/// Resize image using Lanczos filter
+/** @param in tile input data
+    @param w target width
+    @param h target height
+*/
+void filter_interpolate_lanczos( RawTile& in, int w, int h );
 
 /// Rotate image - currently only by 90, 180 or 270 degrees, other values will do nothing
 /** @param in tile input data


### PR DESCRIPTION
The Lanczos filter provides an improvement in visual quality as compared
to the bilinear filter. It seems to provide more sharpess where
sharpness is needed and is not that much slower than the bilinear filter.
It runs between 75-80% as fast as the default bilinear filter.