### PR TITLE
Added configuration to allow CVT to oversample from larger tiles

### DIFF
--- a/README
+++ b/README
@@ -216,6 +216,14 @@ other image formats. This is only necessary if you have activated
 --enable-modules for ./configure and written your own image format 
 handler(s).
 
+OVERSAMPLING_FACTOR: Forces the resize operation to request a source tile N times
+larger than would otherwise be requested prior to performing resize operations.
+Permitted values are 1,2,3 and 4. This factor is useful if very high quality resized 
+tiles are desired since it provides more pixel samples to the resize operation.  
+It also ensures continuous quality is achieved by the resize operation since the
+optimization of returning source tiles directly from the source image in the special
+case where the requested size matches up perfectly with a tile in the source image
+is skipped altogether.
 
 
 

--- a/src/CVT.cc
+++ b/src/CVT.cc
@@ -50,8 +50,9 @@ void CVT::send( Session* session ){
 
 
   // Calculate the number of tiles at the requested resolution
-  unsigned int im_width = (*session->image)->getImageWidth();
-  unsigned int im_height = (*session->image)->getImageHeight();
+  unsigned int im_width = (*session->image)->getImageWidth() / session->oversamplingFactor;
+  unsigned int im_height = (*session->image)->getImageHeight() / session->oversamplingFactor;
+
   int num_res = (*session->image)->getNumResolutions();
 
   // Setup our view with some basic info

--- a/src/Environment.h
+++ b/src/Environment.h
@@ -42,6 +42,7 @@
 #define BASE_URL "";
 #define CACHE_CONTROL "max-age=86400"; // 24 hours
 #define ALLOW_UPSCALING true
+#define OVERSAMPLING_FACTOR 1; // no oversampling is default
 
 
 #include <string>
@@ -247,6 +248,18 @@ class Environment {
     if( envpara ) allow_upscaling =  atoi( envpara ); //implicit cast to boolean, all values other than '0' treated as true
     else allow_upscaling = ALLOW_UPSCALING;
     return allow_upscaling;
+  }
+
+  static int getOversamplingFactor(){
+    int os = OVERSAMPLING_FACTOR;
+    char *envpara = getenv( "OVERSAMPLING_FACTOR" );
+    if( envpara ){
+      os = atoi( envpara );
+      // If not a realistic oversampling factor, set to default
+      if( os < 1 ) os = 1;
+      if( os > 4 ) os = 4;
+    }
+    return os;
   }
 
 };

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -276,6 +276,10 @@ int main( int argc, char *argv[] )
   // Get the allow upscaling setting
   bool allow_upscaling = Environment::getAllowUpscaling();
 
+  // Get the oversampling factor which will result in requesting a tile 
+  // N times larger than would otherwise be requested prior to resize operations
+  int oversamplingFactor = Environment::getOversamplingFactor();
+
 
   // Print out some information
   if( loglevel >= 1 ){
@@ -479,6 +483,7 @@ int main( int argc, char *argv[] )
       session.tileCache = &tileCache;
       session.out = &writer;
       session.watermark = &watermark;
+      session.oversamplingFactor = oversamplingFactor;
       session.headers.clear();
 
       char* header = NULL;

--- a/src/Task.h
+++ b/src/Task.h
@@ -78,6 +78,8 @@ struct Session {
   imageCacheMapType *imageCache;
   Cache* tileCache;
 
+  int oversamplingFactor;
+
 #ifdef DEBUG
   FileWriter* out;
 #else


### PR DESCRIPTION
Added OVERSAMPLING_FACTOR as a configurable option (defaults to 1) with permitted values 1,2,3,4.   When > 1, CVT will attempt to use a tile size that is N times as large as the requested output. This generally leads to higher image quality in the output tile regardless of the resampling algorithm used although depending on the resampling algorithm, this might create more aliasing / sharpness than is desirable.  The sweet spot for the bilinear filter seems to be around 2.  The end user should experiment with combinations of resampling filters and the oversampling factor to achieve the desired quality.