### PR TITLE
OpenJPEG backend: fix misuse of opj_set_decode_area() API

### DIFF
--- a/src/OpenJPEGImage.cc
+++ b/src/OpenJPEGImage.cc
@@ -499,8 +499,18 @@ void OpenJPEGImage::process(unsigned int res, int layers,
     logfile << "INFO :: OpenJPEG :: process() :: Decoding a region (not a single tile)" << endl
             << flush;
 #endif
+
+    // Hack for openjpeg up to 2.2.0
+    for (OPJ_UINT32 i_comp = 0; i_comp < out_image->numcomps; i_comp++){
+      out_image->comps[i_comp].factor = vipsres;
+    }
+
     // Tell OpenJPEG what region we want to decode
-    if (!opj_set_decode_area(l_codec, out_image, xoffset, yoffset, xoffset + tw, yoffset + th)) {
+    if (!opj_set_decode_area(l_codec, out_image,
+                             xoffset << vipsres,
+                             yoffset << vipsres,
+                             (xoffset + tw) << vipsres,
+                             (yoffset + th) << vipsres)) {
       throw file_error("ERROR :: OpenJPEG :: process() :: opj_set_decode_area() failed");
     }
     // Decode region from image


### PR DESCRIPTION
https://github.com/uclouvain/openjpeg/issues/1006 describe in length a current
implementation issue of opj_set_decode_area() combined with
opj_set_decoded_resolution_factor()

Currently, with all openjpeg 2.X, decoding a subwindow of a tiled JPEG2000 image
at a lower resolution results in a corrupted result: only the top-left part of
the output image is filled, due to some tiles not being decoded.
With current openjpeg master, up to https://github.com/uclouvain/openjpeg/commit/5a4a10120a648848de7522245f8671c3ce285dbc,
which implements more efficient sub-tile decoding,
decoding a subwindow of a single-tiled JPEG2000 image at a lower resolution
results in a corrupted image due to some code-blocks not being decoded.

This commit enables IIPRV to work with currently released openjpeg 2.X versions,
as well as the latest openjpeg master (https://github.com/rouault/openjpeg/commit/8f92fc97913bec7ffa2dc10d062c0cdd19da20e4
or later)