### PR TITLE
Fix some typos in comments and documentation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -950,7 +950,7 @@
 
 
 06/06/2008:
-	- Modifed the way the image dimensions are stored in the IIPImage class.
+	- Modified the way the image dimensions are stored in the IIPImage class.
 	  Rather than simply storing the max size, a vector of available dimensions
 	  is saved making it easier to get the size for a given resolution.
 

--- a/fcgi/README
+++ b/fcgi/README
@@ -33,7 +33,7 @@ on http://fastcgi.com/.
 -----
 
  *) When closing connections, shutdown() the send side of TCP sockets to 
-    prevent a TCP RST from trashing the reciept of data on the client (when
+    prevent a TCP RST from trashing the receipt of data on the client (when
     the client continues to send data to the application).
 
  *) [WIN32] force an exit from the ShutdownRequestThread when a shutdown is
@@ -51,7 +51,7 @@ on http://fastcgi.com/.
     streambufs.  Trub, Vladimir [vtrub@purolator.com]
 
  *) Fix a bug a that caused the lib to crash under certain circumstances
-    when an error occured on a read
+    when an error occurred on a read
 
  *) Test for iostreams that support a streambuf assigment operator
 

--- a/fcgi/doc/fcgi-java.htm
+++ b/fcgi/doc/fcgi-java.htm
@@ -58,7 +58,7 @@
       <UL>
          <LI>
             <I>Java Applets</I> are graphical components which are run off HTML pages via the <TT>&lt;APPLET&gt;</TT>
-            HTML extention tag.<BR>
+            HTML extension tag.<BR>
             <BR>
          </LI>
          <LI>

--- a/fcgi/doc/fcgi-perf.htm
+++ b/fcgi/doc/fcgi-perf.htm
@@ -431,7 +431,7 @@
          get all the reliability and maintainability of process isolation, and still get very high performance. If you
          truly need multi-threading, you can write multi-threaded FastCGI and still isolate your multi-threaded
          application from other applications and from the server. In short, multi-threading makes Web server APIs
-         unusable for practially all applications, reducing the choice to FastCGI versus CGI. The performance winner in
+         unusable for practically all applications, reducing the choice to FastCGI versus CGI. The performance winner in
          that contest is obviously FastCGI.
       </P>
       <P>

--- a/fcgi/doc/fcgi-tcl.htm
+++ b/fcgi/doc/fcgi-tcl.htm
@@ -62,7 +62,7 @@
          <LI>
             <I>Demonstrate how easy it is to integrate FastCGI with an existing program.</I> The Tcl interpreter is a
             substantial program, so integrating FastCGI with the Tcl interpreter is a good test of the
-            <TT>fcgi_stdio</TT> compatability library.
+            <TT>fcgi_stdio</TT> compatibility library.
          </LI>
       </UL>
       <P>

--- a/fcgi/include/fcgio.h
+++ b/fcgi/include/fcgio.h
@@ -55,7 +55,7 @@ public:
 
     // Note that if no buf is assigned (the default), iostream methods
     // such as peek(), unget() and putback() will fail.  If a buf is
-    // assigned, I/O is a bit less effecient and output streams will
+    // assigned, I/O is a bit less efficient and output streams will
     // have to be flushed (or the streambuf destroyed) before the next 
     // call to "accept".
     fcgi_streambuf(FCGX_Stream * fcgx, char * buf, int len);

--- a/fcgi/java/FCGIInputStream.java
+++ b/fcgi/java/FCGIInputStream.java
@@ -362,7 +362,7 @@ public class FCGIInputStream extends InputStream
     /*
     * Close the stream. This method does not really exist for BufferedInputStream in java,
     * but is implemented here for compatibility with the FCGI structures being used. It
-    * doent really throw any IOExceptions either, but that's there for compatiblity with
+    * doesn't really throw any IOExceptions either, but that's there for compatibility with
     * the InputStreamInterface.
     */
     public void close() throws IOException{

--- a/fcgi/java/FCGIInterface.java
+++ b/fcgi/java/FCGIInterface.java
@@ -174,7 +174,7 @@ public class FCGIInterface
         isNewConnection = false;
 
         /*
-         * if connection isnt open accept a new connection (blocking)
+         * if connection isn't open accept a new connection (blocking)
          */
         for(;;) {
             if (request.socket == null){

--- a/fcgi/java/FCGIMessage.java
+++ b/fcgi/java/FCGIMessage.java
@@ -21,7 +21,7 @@ import java.util.Properties;
  * For reading incoming mesages, we pass the input
  * stream as a param to the constructor rather than to each method.
  * Methods that build messages use and return internal buffers, so they
- * dont need a stream.
+ * don't need a stream.
  */
 
 public class FCGIMessage
@@ -240,8 +240,8 @@ public class FCGIMessage
         }
         /*
          * No guarantee that we have a request yet, so
-         * dont use fcgi output stream to reference socket, instead
-         * use the FileInputStream that refrences it. Also
+         * don't use fcgi output stream to reference socket, instead
+         * use the FileInputStream that references it. Also
          * nowhere to save exception, since this is not FCGI stream.
          */
 

--- a/fcgi/java/FCGIRequest.java
+++ b/fcgi/java/FCGIRequest.java
@@ -25,7 +25,7 @@ public class FCGIRequest
     * is refrenced by an FCGIInterface class variable . All of this
     * object's data could just as easily be declared directly there.
     * When we thread, this will change, so we might as well use a
-    * seperate class. In line with this thinking, though somewhat
+    * separate class. In line with this thinking, though somewhat
     * more perversely, we kept the socket here.
     */
     /*

--- a/fcgi/libfcgi/fcgiapp.c
+++ b/fcgi/libfcgi/fcgiapp.c
@@ -2066,7 +2066,7 @@ int FCGX_InitRequest(FCGX_Request *request, int sock, int flags)
  *
  * FCGX_Init --
  *
- *      Initilize the FCGX library.  This is called by FCGX_Accept()
+ *      Initialize the FCGX library.  This is called by FCGX_Accept()
  *      but must be called by the user when using FCGX_Accept_r().
  *
  * Results:

--- a/fcgi/libfcgi/os_unix.c
+++ b/fcgi/libfcgi/os_unix.c
@@ -64,7 +64,7 @@ static const char rcsid[] = "$Id: os_unix.c,v 1.37 2002/03/05 19:14:49 robs Exp 
 #endif
 
 /*
- * This structure holds an entry for each oustanding async I/O operation.
+ * This structure holds an entry for each outstanding async I/O operation.
  */
 typedef struct {
     OS_AsyncProc procPtr;	    /* callout completion procedure */

--- a/fcgi/ltmain.sh
+++ b/fcgi/ltmain.sh
@@ -2476,8 +2476,8 @@ EOF
 	      fi
 	    done
 	  else
-	    # Error occured in the first compile.  Let's try to salvage the situation:
-	    # Compile a seperate program for each library.
+	    # Error occurred in the first compile.  Let's try to salvage the situation:
+	    # Compile a separate program for each library.
 	    for i in $deplibs; do
 	      name="`expr $i : '-l\(.*\)'`"
 	     # If $name is empty we are operating on a -L argument.
@@ -4567,7 +4567,7 @@ relink_command=\"$relink_command\""
 	eval "export $shlibpath_var"
       fi
 
-      # Restore saved enviroment variables
+      # Restore saved environment variables
       if test "${save_LC_ALL+set}" = set; then
 	LC_ALL="$save_LC_ALL"; export LC_ALL
       fi

--- a/fcgi/perl/ChangeLog
+++ b/fcgi/perl/ChangeLog
@@ -198,7 +198,7 @@ Version 0.29 -- 10 June 1997 <skimo@dns.ufsia.ac.be> Sven Verdoolaege
 
 Version 0.28 -- 24 February 1997 <skimo@dns.ufsia.ac.be> Sven Verdoolaege
 
-	o Intialization of %ENV did not change environ. Fixed.
+	o Initialization of %ENV did not change environ. Fixed.
 	  Problem reported by Jan Drehmer <Jan.X.Drehmer@telia.se>
 
 Version 0.26 -- 19 February 1997 <skimo@dns.ufsia.ac.be> Sven Verdoolaege

--- a/fcgi/perl/FCGI.PL
+++ b/fcgi/perl/FCGI.PL
@@ -433,7 +433,7 @@ Creates a request handle. It has the following optional parameters:
 =item error perl file handle (default: \*STDERR)
 
 These filehandles will be setup to act as input/output/error
-on succesful Accept.
+on successful Accept.
 
 =item environment hash reference (default: \%ENV)
 

--- a/fcgi/perl/configure
+++ b/fcgi/perl/configure
@@ -2539,7 +2539,7 @@ cat >confcache <<\_ACEOF
 # config.status only pays attention to the cache file if you give it
 # the --recheck option to rerun configure.
 #
-# `ac_cv_env_foo' variables (set or unset) will be overriden when
+# `ac_cv_env_foo' variables (set or unset) will be overridden when
 # loading this file, other *unset* `ac_cv_foo' will be assigned the
 # following values.
 

--- a/man/iipsrv.8
+++ b/man/iipsrv.8
@@ -88,7 +88,7 @@ cropped to the tile size. If smaller, the watermark will be positioned
 randomly within the available space. The image can be either colour or 
 grayscale.
 .IP WATERMARK_PROBABILITY
-The probability that a particular tile will have a watermark 
+The probability that a particular tile will have a watermark
 applied to it. 0 means never, 1 means always.
 .IP WATERMARK_OPACITY
 The opacity (between 0 and 1) applied to the watermark image.

--- a/src/KakaduImage.cc
+++ b/src/KakaduImage.cc
@@ -310,7 +310,7 @@ void KakaduImage::closeImage()
 }
 
 
-// Get an invidual tile
+// Get an individual tile
 RawTile KakaduImage::getTile( int seq, int ang, unsigned int res, int layers, unsigned int tile )
 {
 

--- a/src/Transforms.cc
+++ b/src/Transforms.cc
@@ -676,7 +676,7 @@ void filter_rotate( RawTile& in, float angle=0.0 ){
   // Currently implemented only for rectangular rotations
   if( (int)angle % 90 == 0 && (int)angle % 360 != 0 ){
 
-    // Intialize our counter
+    // Initialize our counter
     unsigned int n = 0;
 
     // Allocate memory for our temporary buffer - rotate function only ever operates on 8bit data


### PR DESCRIPTION
Most of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>