### PR TITLE
divide before multiply to avoid overflow

### DIFF
--- a/src/KakaduImage.cc
+++ b/src/KakaduImage.cc
@@ -380,7 +380,7 @@ RawTile KakaduImage::getTile( int seq, int ang, unsigned int res, int layers, un
   else if( obpc == 8 ) rawtile.data = new unsigned char[tw*th*channels];
   else throw file_error( "Kakadu :: Unsupported number of bits" );
 
-  rawtile.dataLength = tw*th*channels*obpc/8;
+  rawtile.dataLength = tw*th*channels*(obpc/8);
   rawtile.filename = getImagePath();
   rawtile.timestamp = timestamp;
 
@@ -417,7 +417,7 @@ RawTile KakaduImage::getRegion( int seq, int ang, unsigned int res, int layers, 
   else if( obpc == 8 ) rawtile.data = new unsigned char[w*h*channels];
   else throw file_error( "Kakadu :: Unsupported number of bits" );
 
-  rawtile.dataLength = w*h*channels*obpc/8;
+  rawtile.dataLength = w*h*channels*(obpc/8);
   rawtile.filename = getImagePath();
   rawtile.timestamp = timestamp;
 
@@ -647,7 +647,7 @@ void KakaduImage::process( unsigned int res, int layers, int xoffset, int yoffse
 	}
       }
 
-      memcpy( b2, b1, tw * stripe_heights[0] * channels * obpc/8 );
+      memcpy( b2, b1, tw * stripe_heights[0] * channels * (obpc/8) );
 
       // Advance our output buffer pointer
       index += tw * stripe_heights[0] * channels;
@@ -687,7 +687,7 @@ void KakaduImage::process( unsigned int res, int layers, int xoffset, int yoffse
 	}
       }
     }
-    else memcpy( d, buffer, tw*th*channels * obpc/8 );
+    else memcpy( d, buffer, tw*th*channels * (obpc/8) );
 
     // Delete our local buffer
     delete_buffer( buffer );

--- a/src/TileManager.cc
+++ b/src/TileManager.cc
@@ -130,23 +130,23 @@ void TileManager::crop( RawTile *ttt ){
 
   // Create a new buffer, fill it with the old data, then copy
   // back the cropped part into the RawTile buffer
-  int len = tw * th * ttt->channels * ttt->bpc/8;
+  int len = tw * th * ttt->channels * (ttt->bpc/8);
   unsigned char* buffer = (unsigned char*) malloc( len );
   unsigned char* src_ptr = (unsigned char*) memcpy( buffer, ttt->data, len );
   unsigned char* dst_ptr = (unsigned char*) ttt->data;
 
   // Copy one scanline at a time
   for( unsigned int i=0; i<ttt->height; i++ ){
-    len =  ttt->width * ttt->channels * ttt->bpc/8;
+    len =  ttt->width * ttt->channels * (ttt->bpc/8);
     memcpy( dst_ptr, src_ptr, len );
     dst_ptr += len;
-    src_ptr += tw * ttt->channels * ttt->bpc/8;
+    src_ptr += tw * ttt->channels * (ttt->bpc/8);
   }
 
   free( buffer );
 
   // Reset the data length
-  len = ttt->width * ttt->height * ttt->channels * ttt->bpc/8;
+  len = ttt->width * ttt->height * ttt->channels * (ttt->bpc/8);
   ttt->dataLength = len;
   ttt->padded = false;
 
@@ -356,7 +356,7 @@ RawTile TileManager::getRegion( unsigned int res, int seq, int ang, int layers, 
 
   // Create an empty tile with the correct dimensions
   RawTile region( 0, res, seq, ang, width, height, channels, bpc );
-  region.dataLength = width * height * channels * bpc/8;
+  region.dataLength = width * height * channels * (bpc/8);
   region.sampleType = sampleType;
 
   // Allocate memory for the region

--- a/src/Transforms.cc
+++ b/src/Transforms.cc
@@ -533,7 +533,7 @@ void filter_interpolate_nearestneighbour( RawTile& in, unsigned int resampled_wi
   // Correctly set our Rawtile info
   in.width = resampled_width;
   in.height = resampled_height;
-  in.dataLength = resampled_width * resampled_height * channels * in.bpc/8;
+  in.dataLength = resampled_width * resampled_height * channels * (in.bpc/8);
   in.data = output;
 }
 
@@ -616,7 +616,7 @@ void filter_interpolate_bilinear( RawTile& in, unsigned int resampled_width, uns
   // Correctly set our Rawtile info
   in.width = resampled_width;
   in.height = resampled_height;
-  in.dataLength = resampled_width * resampled_height * channels * in.bpc/8;
+  in.dataLength = resampled_width * resampled_height * channels * (in.bpc/8);
   in.data = output;
 }
 
@@ -643,7 +643,7 @@ void filter_contrast( RawTile& in, float c ){
   delete[] (float*) in.data;
   in.data = buffer;
   in.bpc = 8;
-  in.dataLength = np * in.bpc/8;
+  in.dataLength = np * (in.bpc/8);
 }
 
 
@@ -848,7 +848,7 @@ void filter_flatten( RawTile& in, int bands ){
   }
 
   in.channels = bands;
-  in.dataLength = ni * in.bpc/8;
+  in.dataLength = ni * (in.bpc/8);
 }
 
 


### PR DESCRIPTION
Hello, 

I had an integer overflow in the getRegion() method of the TileManager.cc file with the following values.

width : 14240
height : 13395
My in.dataLength was 35363488 because the width*height*channel*bpc was greater than INT_LIMIT before dividing by 8.

So I add parenthesis in each location than I found.

Have a nice day !