### PR TITLE
Fixed: Correct scale factors

### DIFF
--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -191,9 +191,9 @@ void IIIF::run( Session* session, const string& src )
       unsigned int h = (*session->image)->image_heights[i];
       // Only advertise images below our max size value
       if( (max == 0) || (w < max && h < max) ){
-	infoStringStream << "," << endl
-			 << "     { \"width\" : " << w << ", \"height\" : " << h << " }";
-	numUsableResolutions++;
+        infoStringStream << "," << endl
+        << "     { \"width\" : " << w << ", \"height\" : " << h << " }";
+        numUsableResolutions++;
       }
     }
 

--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -202,7 +202,7 @@ void IIIF::run( Session* session, const string& src )
                      << "     { \"width\" : " << tw << ", \"height\" : " << th
                      << ", \"scaleFactors\" : [ 1"; // Scale 1 is original image
 
-    for ( unsigned int i = 1; i < numUsableResolutions; i++ ){
+    for ( unsigned int i = 1; i < numResolutions; i++ ){
       infoStringStream << ", " << pow(2.0, (double)i);
     }
 


### PR DESCRIPTION
When the maxWidth and maxHeight parameters were added to the info.json response, the number of scaleFactors was also adjusted to be set to maxWidth/Height, and not to the actual width and height of the image. 

This had a significant performance regression on image requests in IIIF viewers. Since viewers can actually request images as tiles up to the full width and height, but the `scaleFactors` array assumed it was only up to `maxWidth` or `maxHeight`, the size of tiles requested were very small, and thus slowed down image loading. 

Two videos illustrate this. First, with the 'correct' scale factors:

https://www.dropbox.com/s/biaxchvq0ylipoy/fast-loading-no-max.mov?dl=0

and then with the `scaleFactors` constrained to a maxWidth/Height of 1000:

https://www.dropbox.com/s/avmd9aebiph1ru6/slow-loading-max-params.mov?dl=0

This PR fixes this by reverting the change to the `scaleFactors` calculation from `numUsableResolutions` to just `numResolutions`. 

I believe this is also consistent with the intent of the IIIF 2.1 API.