### PR TITLE
Prevent metadata corruption by throwing file_error() on TIFFError().

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -132,12 +132,25 @@ void IIPSignalHandler( int signal )
   exit( 0 );
 }
 
+void LogTIFFError(const char* module, const char* fmt, va_list ap)
+{
+  char buf[4096];
+  vsnprintf(buf, 4096, fmt, ap);
+  logfile << "TIFF Error :: " << buf << endl;
+  throw file_error(buf);
+}
 
-
-
+void LogTIFFWarning(const char* module, const char* fmt, va_list ap)
+{
+  char buf[4096];
+  vsnprintf(buf, 4096, fmt, ap);
+  logfile << "TIFF Warning :: " << buf << endl;
+}
 
 int main( int argc, char *argv[] )
 {
+  TIFFSetErrorHandler(LogTIFFError);
+  TIFFSetWarningHandler(LogTIFFWarning);
 
   IIPcount = 0;
   int i;


### PR DESCRIPTION
Prevent metadata corruption by throwing file_error() on TIFFError(). Also Log TIFFWarning().

Addresses https://github.com/ruven/iipsrv/issues/168.