### PR TITLE
Added PID with each syslog message

### DIFF
--- a/src/Logger.h
+++ b/src/Logger.h
@@ -48,7 +48,7 @@ class SyslogStream : public std::streambuf {
 
   /// Open a syslog connection
   void open(){
-    openlog( "iipsrv", LOG_NDELAY, LOG_USER );
+    openlog( "iipsrv", LOG_NDELAY | LOG_PID, LOG_USER );
   }
 
   /// Close syslog connection


### PR DESCRIPTION
Hello,

In the project I am working with now I have a cluster of iipimage servers. I collect logs from these instances with Logstash. I needed a way to distinguish logs entries from individual instances in my cluster. I found that it could be done by including PID in every Syslog entry.

Regards.