### PR TITLE
Fixed: Compile with Kakadu > 8.0.0

### DIFF
--- a/src/KakaduImage.cc
+++ b/src/KakaduImage.cc
@@ -215,7 +215,7 @@ void KakaduImage::loadImageInfo( int seq, int ang )
 
   // Check for a palette and LUT - only used for bilevel images for now
   int cmp, plt, stream_id,format=0;
-#if defined(KDU_MAJOR_VERSION) && (KDU_MAJOR_VERSION >= 7) && (KDU_MINOR_VERSION >= 8)
+#if defined(KDU_MAJOR_VERSION) && (KDU_MAJOR_VERSION >= 8 || ((KDU_MAJOR_VERSION >= 7) && (KDU_MINOR_VERSION >= 8)))
   // API change for get_colour_mapping in Kakadu 7.8
   j2k_channels.get_colour_mapping(0,cmp,plt,stream_id,format);
 #else


### PR DESCRIPTION
The preprocessor directive failed to compile with Kakadu 8.0.3 because the minor version was looking for >= 8. This changes it so that version 8+ is recognized as a valid 7.8+ version.