### PR TITLE
Fixed: Reset resolution when calculate resolution is called

### DIFF
--- a/src/View.cc
+++ b/src/View.cc
@@ -28,6 +28,9 @@ using namespace std;
 void View::calculateResolution( unsigned int dimension,
 				unsigned int requested_size ){
 
+  // Reset our resolution level to the smallest available
+  resolution = 0;
+
   // Start from the highest resolution
   int j = max_resolutions - 1;
   unsigned int d = dimension;
@@ -58,9 +61,6 @@ void View::calculateResolution( unsigned int dimension,
 unsigned int View::getResolution(){
 
   unsigned int i;
-
-  // Reset our resolution level to the smallest available
-  resolution = 0;
 
   // Note that we use floor() as that is how our resolutions are calculated
   if( requested_width ) View::calculateResolution( width, floor((float)requested_width/(float)view_width) );


### PR DESCRIPTION
Previously `resolution` was not reset on subsequent calls to `calculateResolution` leading to problems where it was using a previously calculated value for a different dimension.

This fixes it by moving the `resolution` reset to inside the calculateResolution method to ensure it always starts at 0.

Fixes #189