### PR TITLE
Version 1.1 release date fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -73,7 +73,7 @@
 	  potential XSS issues.
 
 
-24/03/2016: Version 1.1 Released
+24/06/2019: Version 1.1 Released
 
 
 20/06/2019:


### PR DESCRIPTION
Version 1.1 of iipsrv was released on 24/06/2019 according to https://iipimage.sourceforge.io/2019/06/iipsrv-1-1-released/.