### PR TITLE
Option to apply watermaking across complete (CVT/IIIF) images

### DIFF
--- a/README
+++ b/README
@@ -198,6 +198,15 @@ applied to it. 0 means never, 1 means always.
 
 WATERMARK_OPACITY: The opacity (between 0 and 1) applied to the watermark image.
 
+WATERMARK_MIN_CVT: Minimum dimensions at which to apply watermarking to CVT/IIIF 
+images. 0 means don't apply to these images (default). So e.g. 300 means only apply 
+to images which are at least 300 pixels wide and at least 300 pixels high.
+
+WATERMARK_REPEAT: If watermarking is applied to CVT/IIIF images, they are considered 
+as a series of tiles, and WATERMARK_PROBABILITY is used to decide whether to apply a 
+watermark to each tile. WATERMARK_REPEAT defines the width and height of these tiles; 
+if it is 0 (default) then no watermark will be applied (default).
+
 MEMCACHED_SERVERS: A comma-delimitted list of memcached servers with optional
 port numbers. For example: localhost,192.168.0.1:8888,192.168.0.2.
 

--- a/README
+++ b/README
@@ -202,11 +202,6 @@ WATERMARK_MIN_CVT: Minimum dimensions at which to apply watermarking to CVT/IIIF
 images. 0 means don't apply to these images (default). So e.g. 300 means only apply 
 to images which are at least 300 pixels wide and at least 300 pixels high.
 
-WATERMARK_REPEAT: If watermarking is applied to CVT/IIIF images, they are considered 
-as a series of tiles, and WATERMARK_PROBABILITY is used to decide whether to apply a 
-watermark to each tile. WATERMARK_REPEAT defines the width and height of these tiles; 
-if it is 0 (default) then no watermark will be applied (default).
-
 MEMCACHED_SERVERS: A comma-delimitted list of memcached servers with optional
 port numbers. For example: localhost,192.168.0.1:8888,192.168.0.2.
 

--- a/src/CVT.cc
+++ b/src/CVT.cc
@@ -481,6 +481,22 @@ void CVT::send( Session* session ){
   }
 
 
+  // Apply repeating watermark if that's been specified
+  Watermark* watermark = session->watermark;
+  if( watermark && watermark->isSet() && (watermark->getRepeat() > 0) && (watermark->getMinCVT() > 0)){
+  
+    if( (complete_image.width >= watermark->getMinCVT()) && (complete_image.height >= watermark->getMinCVT())){
+  
+      if( session->loglevel >= 2 ) function_timer.start();
+
+      watermark->apply( complete_image.data, watermark->getRepeat(), complete_image.width, complete_image.height, complete_image.channels, complete_image.bpc );
+
+      if( session->loglevel >= 2 ) *(session->logfile) << "CVT :: Repeating watermark applied: " << function_timer.getTime()
+         << " microseconds" << endl;
+    }
+  }
+
+
   // Set the physical output resolution for this particular view and zoom level
   if( (*session->image)->dpi_x > 0 && (*session->image)->dpi_y > 0 ){
     float dpi_x = (*session->image)->dpi_x * (float) im_width / (float) (*session->image)->getImageWidth();

--- a/src/CVT.cc
+++ b/src/CVT.cc
@@ -483,13 +483,13 @@ void CVT::send( Session* session ){
 
   // Apply repeating watermark if that's been specified
   Watermark* watermark = session->watermark;
-  if( watermark && watermark->isSet() && (watermark->getRepeat() > 0) && (watermark->getMinCVT() > 0)){
+  if( watermark && watermark->isSet() && (watermark->getMinCVT() > 0)){
   
     if( (complete_image.width >= watermark->getMinCVT()) && (complete_image.height >= watermark->getMinCVT())){
   
       if( session->loglevel >= 2 ) function_timer.start();
 
-      watermark->apply( complete_image.data, watermark->getRepeat(), complete_image.width, complete_image.height, complete_image.channels, complete_image.bpc );
+      watermark->apply( complete_image.data, (*session->image)->getTileWidth(), complete_image.width, complete_image.height, complete_image.channels, complete_image.bpc );
 
       if( session->loglevel >= 2 ) *(session->logfile) << "CVT :: Repeating watermark applied: " << function_timer.getTime()
          << " microseconds" << endl;

--- a/src/Environment.h
+++ b/src/Environment.h
@@ -37,6 +37,8 @@
 #define WATERMARK ""
 #define WATERMARK_PROBABILITY 1.0
 #define WATERMARK_OPACITY 1.0
+#define WATERMARK_MIN_CVT 0
+#define WATERMARK_REPEAT 0
 #define LIBMEMCACHED_SERVERS "localhost"
 #define LIBMEMCACHED_TIMEOUT 86400  // 24 hours
 #define INTERPOLATION 1  // 1: Bilinear
@@ -215,6 +217,30 @@ class Environment {
     }
 
     return watermark_opacity;
+  }
+
+
+  static int getWatermarkRepeat(){
+    unsigned int watermark_repeat = WATERMARK_REPEAT;
+    char* envpara = getenv( "WATERMARK_REPEAT" );
+
+    if( envpara ){
+      watermark_repeat = atoi( envpara );
+    }
+
+    return watermark_repeat;
+  }
+
+
+  static int getWatermarkMinCVT(){
+    unsigned int watermark_min_cvt = WATERMARK_MIN_CVT;
+    char* envpara = getenv( "WATERMARK_MIN_CVT" );
+
+    if( envpara ){
+      watermark_min_cvt = atoi( envpara );
+    }
+
+    return watermark_min_cvt;
   }
 
 

--- a/src/Environment.h
+++ b/src/Environment.h
@@ -38,7 +38,6 @@
 #define WATERMARK_PROBABILITY 1.0
 #define WATERMARK_OPACITY 1.0
 #define WATERMARK_MIN_CVT 0
-#define WATERMARK_REPEAT 0
 #define LIBMEMCACHED_SERVERS "localhost"
 #define LIBMEMCACHED_TIMEOUT 86400  // 24 hours
 #define INTERPOLATION 1  // 1: Bilinear
@@ -217,18 +216,6 @@ class Environment {
     }
 
     return watermark_opacity;
-  }
-
-
-  static int getWatermarkRepeat(){
-    unsigned int watermark_repeat = WATERMARK_REPEAT;
-    char* envpara = getenv( "WATERMARK_REPEAT" );
-
-    if( envpara ){
-      watermark_repeat = atoi( envpara );
-    }
-
-    return watermark_repeat;
   }
 
 

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -298,8 +298,7 @@ int main( int argc, char *argv[] )
   Watermark watermark( Environment::getWatermark(),
 		       Environment::getWatermarkOpacity(),
 		       Environment::getWatermarkProbability(),
-		       Environment::getWatermarkMinCVT(),
-		       Environment::getWatermarkRepeat() );
+		       Environment::getWatermarkMinCVT() );
 
 
   // Get the CORS setting
@@ -425,7 +424,6 @@ int main( int argc, char *argv[] )
 		<< "': setting probability to " << watermark.getProbability()
 		<< " and opacity to " << watermark.getOpacity()
 		<< "; CVT threshold to " << watermark.getMinCVT()
-		<< " and repeat to " << watermark.getRepeat()
 		<< endl;
       }
       else{

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -297,7 +297,9 @@ int main( int argc, char *argv[] )
   // Set up our watermark object
   Watermark watermark( Environment::getWatermark(),
 		       Environment::getWatermarkOpacity(),
-		       Environment::getWatermarkProbability() );
+		       Environment::getWatermarkProbability(),
+		       Environment::getWatermarkMinCVT(),
+		       Environment::getWatermarkRepeat() );
 
 
   // Get the CORS setting
@@ -421,7 +423,10 @@ int main( int argc, char *argv[] )
       if( watermark.isSet() ){
 	logfile << "Loaded watermark image '" << watermark.getImage()
 		<< "': setting probability to " << watermark.getProbability()
-		<< " and opacity to " << watermark.getOpacity() << endl;
+		<< " and opacity to " << watermark.getOpacity()
+		<< "; CVT threshold to " << watermark.getMinCVT()
+		<< " and repeat to " << watermark.getRepeat()
+		<< endl;
       }
       else{
 	logfile << "Unable to load watermark image '" << watermark.getImage() << "'" << endl;

--- a/src/TileManager.cc
+++ b/src/TileManager.cc
@@ -47,7 +47,7 @@ RawTile TileManager::getNewTile( int resolution, int tile, int xangle, int yangl
     unsigned int tw = ttt.padded? image->getTileWidth() : ttt.width;
     unsigned int th = ttt.padded? image->getTileHeight() : ttt.height;
 
-    watermark->apply( ttt.data, tw, th, ttt.channels, ttt.bpc );
+    watermark->apply( ttt.data, 0, tw, th, ttt.channels, ttt.bpc );
     if( loglevel >= 4 ) *logfile << "TileManager :: Watermark applied: " << insert_timer.getTime()
 				 << " microseconds" << endl;
   }

--- a/src/Watermark.cc
+++ b/src/Watermark.cc
@@ -130,7 +130,7 @@ void Watermark::apply( void* data, unsigned int repeatStep, unsigned int width, 
       yoffset += random * (availablespace - _height);
     }
 
-     // Limit the area of the watermark to the size of the tile
+    // Limit the area of the watermark to the size of the tile
     unsigned int xlimit = _width;
     unsigned int ylimit = _height;
     if( _width > width ) xlimit = width;
@@ -138,31 +138,31 @@ void Watermark::apply( void* data, unsigned int repeatStep, unsigned int width, 
 
     for( unsigned int j=0; j<ylimit; j++ ){
       for( unsigned int i=0; i<xlimit; i++ ){
-        for( unsigned int k=0; k<channels; k++ ){
+	for( unsigned int k=0; k<channels; k++ ){
 
-          unsigned int id = (j+yoffset)*width*channels + (i+xoffset)*channels + k;
+	  unsigned int id = (j+yoffset)*width*channels + (i+xoffset)*channels + k;
 
-          // For 16bit images we need to multiply up as our watermark data is always 8bit
-          // We do our maths in unsigned int to allow us to clip correctly
-          if( bpc == 16 ){
-            unsigned short* d = (unsigned short*) data;
-            unsigned int t = (unsigned int)( d[id] + _watermark[j*_width*_channels + i*_channels + k]*256 );
-            if( t > 65535 ) t = 65535;
-            d[id] = (unsigned short) t;
-          }
-
-          // TIFFReadRGBAImage always scales to 8bit, so never any need for downscaling, but clip to 255
-          // We do our maths in unsigned short to allow us to clip correctly after
-          else{
-            unsigned char* d = (unsigned char*) data;
-            unsigned short t = (unsigned short)( d[id] + _watermark[j*_width*_channels + i*_channels + k] );
-            if( t > 255 ) t = 255;
-            d[id] = (unsigned char) t;
-          }
-        }
+	  // For 16bit images we need to multiply up as our watermark data is always 8bit
+	  // We do our maths in unsigned int to allow us to clip correctly
+	  if( bpc == 16 ){
+	    unsigned short* d = (unsigned short*) data;
+	    unsigned int t = (unsigned int)( d[id] + _watermark[j*_width*_channels + i*_channels + k]*256 );
+	    if( t > 65535 ) t = 65535;
+	    d[id] = (unsigned short) t;
+	  }
+	  // TIFFReadRGBAImage always scales to 8bit, so never any need for downscaling, but clip to 255
+	  // We do our maths in unsigned short to allow us to clip correctly after
+	  else{
+	    unsigned char* d = (unsigned char*) data;
+ 	    unsigned short t = (unsigned short)( d[id] + _watermark[j*_width*_channels + i*_channels + k] );
+	    if( t > 255 ) t = 255;
+ 	    d[id] = (unsigned char) t;
+	  }
+	}
       }
     }
   }
+
     }
   }
 

--- a/src/Watermark.cc
+++ b/src/Watermark.cc
@@ -105,62 +105,64 @@ void Watermark::apply( void* data, unsigned int repeatStep, unsigned int width, 
   for (bigxoffset = 0; bigxoffset < (width - _width); bigxoffset += repeatIncrement) {
     for (bigyoffset = 0; bigyoffset < (height - _height); bigyoffset += repeatIncrement) {
 
-      // Get random number as a float between 0 and 1
-      random = (float) rand() / RAND_MAX;
+  // indentation reduced to make diffing easier.
 
-      // Only apply if our random number is less than our given probability
-      if( random < _probability ){
-    
-        // Vary watermark position randomly within the tile depending on available space
-        unsigned int xoffset = bigxoffset;
-        availablespace = width - xoffset;
-        if (repeatStep > 0) availablespace = std::min(availablespace, repeatStep);
-        if( availablespace > _width ){
-          random = (float) rand() / RAND_MAX;
-          xoffset += random * (availablespace - _width);
-        }
-    
-        unsigned int yoffset = bigyoffset;
-        availablespace = height - yoffset;
-        if (repeatStep > 0) availablespace = std::min(availablespace, repeatStep);
-        if( availablespace > _height ){
-          random = (float) rand() / RAND_MAX;
-          yoffset += random * (availablespace - _height);
-        }
-    
-         // Limit the area of the watermark to the size of the tile
-        unsigned int xlimit = _width;
-        unsigned int ylimit = _height;
-        if( _width > width ) xlimit = width;
-        if( _height > height ) ylimit = height;
-    
-        for( unsigned int j=0; j<ylimit; j++ ){
-          for( unsigned int i=0; i<xlimit; i++ ){
-            for( unsigned int k=0; k<channels; k++ ){
-    
-              unsigned int id = (j+yoffset)*width*channels + (i+xoffset)*channels + k;
-    
-              // For 16bit images we need to multiply up as our watermark data is always 8bit
-              // We do our maths in unsigned int to allow us to clip correctly
-              if( bpc == 16 ){
-                unsigned short* d = (unsigned short*) data;
-                unsigned int t = (unsigned int)( d[id] + _watermark[j*_width*_channels + i*_channels + k]*256 );
-                if( t > 65535 ) t = 65535;
-                d[id] = (unsigned short) t;
-              }
-    
-              // TIFFReadRGBAImage always scales to 8bit, so never any need for downscaling, but clip to 255
-              // We do our maths in unsigned short to allow us to clip correctly after
-              else{
-                unsigned char* d = (unsigned char*) data;
-                unsigned short t = (unsigned short)( d[id] + _watermark[j*_width*_channels + i*_channels + k] );
-                if( t > 255 ) t = 255;
-                d[id] = (unsigned char) t;
-              }
-            }
+  // Get random number as a float between 0 and 1
+  random = (float) rand() / RAND_MAX;
+
+  // Only apply if our random number is less than our given probability
+  if( random < _probability ){
+
+    // Vary watermark position randomly within the tile depending on available space
+    unsigned int xoffset = bigxoffset;
+    availablespace = width - xoffset;
+    if (repeatStep > 0) availablespace = std::min(availablespace, repeatStep);
+    if( availablespace > _width ){
+      random = (float) rand() / RAND_MAX;
+      xoffset += random * (availablespace - _width);
+    }
+
+    unsigned int yoffset = bigyoffset;
+    availablespace = height - yoffset;
+    if (repeatStep > 0) availablespace = std::min(availablespace, repeatStep);
+    if( availablespace > _height ){
+      random = (float) rand() / RAND_MAX;
+      yoffset += random * (availablespace - _height);
+    }
+
+     // Limit the area of the watermark to the size of the tile
+    unsigned int xlimit = _width;
+    unsigned int ylimit = _height;
+    if( _width > width ) xlimit = width;
+    if( _height > height ) ylimit = height;
+
+    for( unsigned int j=0; j<ylimit; j++ ){
+      for( unsigned int i=0; i<xlimit; i++ ){
+        for( unsigned int k=0; k<channels; k++ ){
+
+          unsigned int id = (j+yoffset)*width*channels + (i+xoffset)*channels + k;
+
+          // For 16bit images we need to multiply up as our watermark data is always 8bit
+          // We do our maths in unsigned int to allow us to clip correctly
+          if( bpc == 16 ){
+            unsigned short* d = (unsigned short*) data;
+            unsigned int t = (unsigned int)( d[id] + _watermark[j*_width*_channels + i*_channels + k]*256 );
+            if( t > 65535 ) t = 65535;
+            d[id] = (unsigned short) t;
+          }
+
+          // TIFFReadRGBAImage always scales to 8bit, so never any need for downscaling, but clip to 255
+          // We do our maths in unsigned short to allow us to clip correctly after
+          else{
+            unsigned char* d = (unsigned char*) data;
+            unsigned short t = (unsigned short)( d[id] + _watermark[j*_width*_channels + i*_channels + k] );
+            if( t > 255 ) t = 255;
+            d[id] = (unsigned char) t;
           }
         }
       }
+    }
+  }
     }
   }
 

--- a/src/Watermark.h
+++ b/src/Watermark.h
@@ -66,9 +66,6 @@ class Watermark {
   /// Watermark min CVT to apply
   unsigned int _mincvt;
 
-  /// Watermark repeat step for CVT
-  unsigned int _repeat;
-
   /// Whether we have a valid watermark
   bool _isSet;
 
@@ -85,7 +82,6 @@ class Watermark {
     _opacity = 0.0;
     _probability = 0.0;
     _mincvt = 0;
-    _repeat = 0;
   };
 
   /// Constructor
@@ -93,7 +89,7 @@ class Watermark {
       @param opacity opacity applied to watermark
       @param probability probability that watermark will be applied to a particular tile
    */
-  Watermark( const std::string& file, float opacity, float probability, unsigned int repeat, unsigned int mincvt ){
+  Watermark( const std::string& file, float opacity, float probability, unsigned int mincvt ){
     _image = file;
     _width = 0;
     _height = 0;
@@ -102,7 +98,6 @@ class Watermark {
     _opacity = opacity;
     _probability = probability;
     _mincvt = mincvt;
-    _repeat = repeat;
     _isSet = false;
     _watermark = NULL;
   };
@@ -132,9 +127,6 @@ class Watermark {
 
   /// Return watermark threshold for CVT
   float getMinCVT(){ return _mincvt; };
-
-  /// Return watermark repeat step for CVT
-  float getRepeat(){ return _repeat; };
 
   /// Initialize our watermark image
   void init();

--- a/src/Watermark.h
+++ b/src/Watermark.h
@@ -63,6 +63,12 @@ class Watermark {
   /// Watermark probability
   float _probability;
 
+  /// Watermark min CVT to apply
+  unsigned int _mincvt;
+
+  /// Watermark repeat step for CVT
+  unsigned int _repeat;
+
   /// Whether we have a valid watermark
   bool _isSet;
 
@@ -78,6 +84,8 @@ class Watermark {
     _watermark = NULL;
     _opacity = 0.0;
     _probability = 0.0;
+    _mincvt = 0;
+    _repeat = 0;
   };
 
   /// Constructor
@@ -85,7 +93,7 @@ class Watermark {
       @param opacity opacity applied to watermark
       @param probability probability that watermark will be applied to a particular tile
    */
-  Watermark( const std::string& file, float opacity, float probability ){
+  Watermark( const std::string& file, float opacity, float probability, unsigned int repeat, unsigned int mincvt ){
     _image = file;
     _width = 0;
     _height = 0;
@@ -93,6 +101,8 @@ class Watermark {
     _bpc = 0;
     _opacity = opacity;
     _probability = probability;
+    _mincvt = mincvt;
+    _repeat = repeat;
     _isSet = false;
     _watermark = NULL;
   };
@@ -109,7 +119,7 @@ class Watermark {
       @param channels number of channels
       @param bpc bits per channel (8 or 16)
     */
-  void apply( void* data, unsigned int width, unsigned int height, unsigned int channels, unsigned int bpc );
+  void apply( void* data, unsigned int repeatTileSize, unsigned int width, unsigned int height, unsigned int channels, unsigned int bpc );
 
   /// Return watermark image path
   std::string getImage(){ return _image; };
@@ -119,6 +129,12 @@ class Watermark {
 
   /// Return watermark probability
   float getProbability(){ return _probability; };
+
+  /// Return watermark threshold for CVT
+  float getMinCVT(){ return _mincvt; };
+
+  /// Return watermark repeat step for CVT
+  float getRepeat(){ return _repeat; };
 
   /// Initialize our watermark image
   void init();


### PR DESCRIPTION
(See issue #218) This PR adds two new environment variables WATERMARK_MIN_CVT and WATERMARK_REPEAT. If either are missing or zero, behavious is unchanged. However, if both are non-zero, and if the other Watermarking variables are set and valid, then watermarks will be applied to CVT/IIIF images in approximately the same manner as they are applied to tiles.

WATERMARK_MIN_CVT sets a threshold below which no watermarking will take place - this allows smaller images, such as thumbnails or small previews, not to be watermarked. If the threshold is met, then the complete image is treated as if it was a series of tiles, and the watermark is applied to each tile in the same way that it would be to an individual tile, i.e. using the WATERMARK_PROBABILITY to decide whether to apply a watermark.

WATERMARK_REPEAT sets the size of the conceptual tiles. This could be a constant, but I couldn't see that there was an obvious constant to use - I may have missed it. Arguably it gives the implementer more control to have this as a separate value however.

(If you have any questions or comments please contact me at benr@cogapp.com - many thanks,)