### PR TITLE
Fixed: Correct profile value for IIIFv2

### DIFF
--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -256,7 +256,7 @@ void IIIF::run( Session* session, const string& src )
     else {
       infoStringStream << "  \"@id\" : \"" << iiif_id << "\"," << endl
 		       << "  \"profile\" : [" << endl
-		       << "     \"" << IIIF_PROTOCOL << "/" << iiif_version << "/" << IIIF_PROFILE << "\"," << endl
+		       << "     \"" << IIIF_PROTOCOL << "/" << iiif_version << "/" << IIIF_PROFILE << ".json\"," << endl
 		       << "     { \"formats\" : [ \"jpg\", \"png\" ]," << endl
 		       << "       \"qualities\" : [\"native\",\"color\",\"gray\",\"bitonal\"]," << endl
 		       << "       \"supports\" : [\"regionByPct\",\"regionSquare\",\"sizeByForcedWh\",\"sizeByWh\",\"sizeAboveFull\",\"sizeUpscaling\",\"rotationBy90s\",\"mirroring\"]," << endl


### PR DESCRIPTION
The correct profile value for IIIFv2 service blocks includes the ".json" suffix for the
profile document (See the example given at https://iiif.io/api/image/2.1/#profile-description).