### PR TITLE
IIIF v3: confined size (!w,h) should clamp to region instead of rejecting

### DIFF
--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -467,6 +467,10 @@ void IIIF::run( Session* session, const string& src )
       string sizeString = izer.nextToken();
       transform( sizeString.begin(), sizeString.end(), sizeString.begin(), ::tolower );
 
+      // Flag for confined "!w,h" requests, which must be clamped to the region
+      // rather than rejected when the source is smaller than the box (#271)
+      bool confined = false;
+
       // Calculate the width and height of our region at full resolution
       requested_width = region[2] * width;   // view->getViewWidth not trustworthy yet (no resolution set)
       requested_height = region[3] * height;
@@ -502,7 +506,7 @@ void IIIF::run( Session* session, const string& src )
       else{
 
         // !w,h request (do not break aspect ratio) - remove the !, store the info and continue usual parsing
-        if ( sizeString.substr(0, 1) == "!" ) sizeString.erase(0, 1);
+        if ( sizeString.substr(0, 1) == "!" ){ sizeString.erase(0, 1); confined = true; }
         // Otherwise tell our view it can break aspect ratio
         else session->view->maintain_aspect = false;
 
@@ -547,10 +551,22 @@ void IIIF::run( Session* session, const string& src )
         throw invalid_argument( "IIIF: invalid size: requested width or height < 0" );
       }
 
-      // Check for malformed upscaling request
-      if( iiif_version >= 3 ){
-	if( session->view->allow_upscaling == false &&
-	    ( requested_width > round(width*region[2]) || requested_height > round(height*region[3]) ) ){
+      // Check for upscaling request
+      if( iiif_version >= 3 && session->view->allow_upscaling == false &&
+	  ( requested_width > round(width*region[2]) || requested_height > round(height*region[3]) ) ){
+	// A confined "!w,h" request must return the largest image that fits
+	// within the region rather than be rejected when the source is smaller
+	// than the requested box (IIIF Image API 3.0 §4.2, issue #271). Clamp
+	// the requested size down to the region; aspect ratio is preserved
+	// downstream in View::getRequestSize(). Other size forms that exceed the
+	// region are genuine upscaling and remain an error.
+	if( confined ){
+	  unsigned int region_width = round( width * region[2] );
+	  unsigned int region_height = round( height * region[3] );
+	  requested_width = std::min( requested_width, region_width );
+	  requested_height = std::min( requested_height, region_height );
+	}
+	else{
 	  throw invalid_argument( "IIIF: upscaling should be prefixed with ^" );
 	}
       }

--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -55,6 +55,13 @@ string IIIF::extra_info = "";
 bool IIIF::extensions;
 
 
+// Clamp a requested extent down to the region extent (used for confined "!w,h"
+// requests that must fit within the region rather than upscale - see issue #271).
+static inline unsigned int clamp_to_region( unsigned int requested, unsigned int region_extent ){
+  return ( requested > region_extent ) ? region_extent : requested;
+}
+
+
 // The request is in the form {identifier}/{region}/{size}/{rotation}/{quality}{.format}
 //     eg. filename.tif/full/full/0/native.jpg
 // or in the form {identifier}/info.json
@@ -506,7 +513,9 @@ void IIIF::run( Session* session, const string& src )
       else{
 
         // !w,h request (do not break aspect ratio) - remove the !, store the info and continue usual parsing
-        if ( sizeString.substr(0, 1) == "!" ){ sizeString.erase(0, 1); confined = true; }
+        // #271: capture the confined flag before the '!' is stripped below
+        confined = ( !sizeString.empty() && sizeString[0] == '!' );
+        if ( sizeString.substr(0, 1) == "!" ) sizeString.erase(0, 1);
         // Otherwise tell our view it can break aspect ratio
         else session->view->maintain_aspect = false;
 
@@ -551,24 +560,21 @@ void IIIF::run( Session* session, const string& src )
         throw invalid_argument( "IIIF: invalid size: requested width or height < 0" );
       }
 
-      // Check for upscaling request
-      if( iiif_version >= 3 && session->view->allow_upscaling == false &&
-	  ( requested_width > round(width*region[2]) || requested_height > round(height*region[3]) ) ){
-	// A confined "!w,h" request must return the largest image that fits
-	// within the region rather than be rejected when the source is smaller
-	// than the requested box (IIIF Image API 3.0 §4.2, issue #271). Clamp
-	// the requested size down to the region; aspect ratio is preserved
-	// downstream in View::getRequestSize(). Other size forms that exceed the
-	// region are genuine upscaling and remain an error.
-	if( confined ){
-	  unsigned int region_width = round( width * region[2] );
-	  unsigned int region_height = round( height * region[3] );
-	  requested_width = ( requested_width > region_width ) ? region_width : requested_width;
-	  requested_height = ( requested_height > region_height ) ? region_height : requested_height;
-	}
-	else{
-	  throw invalid_argument( "IIIF: upscaling should be prefixed with ^" );
-	}
+      // Check for upscaling request. A confined "!w,h" request that exceeds the
+      // region is clamped down to fit within it (issue #271, IIIF Image API 3.0
+      // §4.2) rather than rejected; aspect ratio is preserved downstream in
+      // View::getRequestSize(). Any other size form that exceeds the region without
+      // a '^' prefix is genuine upscaling and remains an error.
+      bool over_region = ( iiif_version >= 3 && session->view->allow_upscaling == false &&
+			   ( requested_width > round(width*region[2]) || requested_height > round(height*region[3]) ) );
+      if( over_region && confined ){
+	unsigned int region_width = round( width * region[2] );
+	unsigned int region_height = round( height * region[3] );
+	requested_width = clamp_to_region( requested_width, region_width );
+	requested_height = clamp_to_region( requested_height, region_height );
+      }
+      else if( over_region ){
+	throw invalid_argument( "IIIF: upscaling should be prefixed with ^" );
       }
 
       // Limit our requested size to the maximum allowable size if necessary

--- a/src/IIIF.cc
+++ b/src/IIIF.cc
@@ -563,8 +563,8 @@ void IIIF::run( Session* session, const string& src )
 	if( confined ){
 	  unsigned int region_width = round( width * region[2] );
 	  unsigned int region_height = round( height * region[3] );
-	  requested_width = std::min( requested_width, region_width );
-	  requested_height = std::min( requested_height, region_height );
+	  requested_width = ( requested_width > region_width ) ? region_width : requested_width;
+	  requested_height = ( requested_height > region_height ) ? region_height : requested_height;
 	}
 	else{
 	  throw invalid_argument( "IIIF: upscaling should be prefixed with ^" );


### PR DESCRIPTION
Fixes #271.

In IIIF Image API v3, a confined size request `!w,h` against a region smaller
than the box returns HTTP 400 ("upscaling should be prefixed with ^") instead
of the region at its own size.

## Spec

v3 §4.2, `!w,h`: the result must be "as large as possible but not larger than
the extracted region, w or h", aspect preserved. Upscaling uses the separate
`^` prefix. So `!300,300` on a 200×200 region should return 200×200, not 400.

## Cause

The upscale guard in IIIF.cc (around line 551) throws whenever a requested
dimension exceeds the region, with no special case for the confined `!` flag.
`!` is stripped at line 505 without recording that the request was confined, so
later there's no way to tell it apart from a forced `w,h`. maintain_aspect
doesn't help — it's also set for `,h` and `w,`, which are genuine upscale
requests that should still throw.

One thing to flag: the downstream aspect fit in View::getRequestSize() has no
no-upscale clamp, so this guard is currently the only thing preventing
upscaling. The clamp therefore has to happen here, in the parse path.

## Fix

Record a `confined` flag where `!` is detected. In the v3 upscale guard, when
the request is confined and exceeds the region, clamp the requested dimensions
to the region instead of throwing; the downstream aspect fit then produces the
correct result. Forced `w,h` and single-dimension `,h` / `w,` still throw, and
`^!w,h` still upscales.

The clamp is per-dimension against the region rather than reusing the nearby
max_size clamp, because the region can be non-square while max_size is a scalar
cap.

## Verification

Confirmed against the parse logic at IIIF.cc:479-571 (current master), run
through the full chain including View::getRequestSize():

| size (v3, no-upscale) | source | result |
|---|---|---|
| !300,300 | 200×200 | 200×200 (was: 400) |
| 300,300 (forced) | 200×200 | 400 (unchanged) |
| ,300 / 300, | 200×200 | 400 (unchanged) |
| ^!300,300 | 200×200 | 300×300 (unchanged) |
| !300,300 | 400×200 | 300×150 |
| !300,300 | 100×200 | 100×200 |

iipsrv has no test suite in-tree, so this was verified with an isolated harness
running the parse block verbatim. A no-upscale test case modelled on the IIIF
validator's size_noup.py would be the natural place for this to live
permanently.